### PR TITLE
Add new functions in mutter

### DIFF
--- a/src/compositor/meta-background.c
+++ b/src/compositor/meta-background.c
@@ -1301,3 +1301,31 @@ meta_background_get_filename (MetaBackground *self)
 {
     return self->priv->filename;
 }
+
+/**
+ * meta_background_get_texture_rect:
+ * @self: a #MetaBackground
+ *
+ * Returns: (transfer full): the newly allocated #ClutterRect with the
+ * rectangular region of the background. Use clutter_rect_free() to free its
+ * resources.
+ */
+ClutterRect *
+meta_background_get_texture_rect (MetaBackground *self)
+{
+    MetaBackgroundPrivate *priv = self->priv;
+    MetaRectangle monitor_geometry;
+    ClutterActorBox actor_box;
+    float texture_x_scale, texture_y_scale;
+    cairo_rectangle_int_t texture_area;
+
+    meta_screen_get_monitor_geometry (priv->screen, priv->monitor, &monitor_geometry);
+    actor_box.x1 = 0;
+    actor_box.y1 = 0;
+    actor_box.x2 = monitor_geometry.width;
+    actor_box.y2 = monitor_geometry.height;
+
+    get_texture_area_and_scale (self, &actor_box, &texture_area, &texture_x_scale, &texture_y_scale);
+
+    return clutter_rect_init (clutter_rect_alloc (), 0, 0, texture_area.width, texture_area.height);
+}

--- a/src/meta/meta-background.h
+++ b/src/meta/meta-background.h
@@ -110,5 +110,6 @@ GDesktopBackgroundShading meta_background_get_shading (MetaBackground *self);
 const ClutterColor *meta_background_get_color (MetaBackground *self);
 const ClutterColor *meta_background_get_second_color (MetaBackground *self);
 gboolean meta_background_get_has_alpha (MetaBackground *self);
+ClutterRect *meta_background_get_texture_rect (MetaBackground *self);
 
 #endif /* META_BACKGROUND_H */


### PR DESCRIPTION
We need a couple of new functions to get more information about the texture being rendered in background.

More specifically, we need to know:
- If texture has alpha
- Size of texture once it is zoomed/scaled/centered/whatever

[endlessm/eos-shell#2387]
