### PR TITLE
MonitorManager: Ignore outputs with an assigned CRTC

### DIFF
--- a/src/core/monitor-xrandr.c
+++ b/src/core/monitor-xrandr.c
@@ -1315,6 +1315,9 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
       int current_width, current_height;
       int target_width, target_height;
 
+      if (!output->crtc)
+        continue;
+
       current_width = output->crtc->current_mode->width;
       current_height = output->crtc->current_mode->height;
 


### PR DESCRIPTION
It will be assigned a bit later.

[endlessm/eos-shell#3162]
