### PR TITLE
MonitorManager: Take into account all monitors when setting the fb size

### DIFF
--- a/src/core/monitor-xrandr.c
+++ b/src/core/monitor-xrandr.c
@@ -1293,6 +1293,9 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
   gboolean new_config;
   unsigned i, j;
   gboolean needs_update = FALSE;
+  int width_mm, height_mm;
+  int screen_width = 0;
+  int screen_height = 0;
 
   if ((event->type - manager_xrandr->rr_event_base) != RRScreenChangeNotify)
     return FALSE;
@@ -1308,6 +1311,8 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
 
   manager->serial++;
   meta_monitor_manager_xrandr_read_current (manager);
+
+  meta_display_grab (meta_get_display ());
 
   for (i = 0; i < (unsigned)manager->n_outputs; i++)
     {
@@ -1341,10 +1346,7 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
               (current_width != mode->width ||
                current_height != mode->height))
             {
-              int width_mm, height_mm;
               Status ok;
-
-              meta_display_grab (meta_get_display ());
 
               XRRSetCrtcConfig (manager_xrandr->xdisplay,
                                 manager_xrandr->resources,
@@ -1357,22 +1359,6 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
 
               output->crtc->current_mode = mode;
 
-              width_mm = (mode->width / DPI_FALLBACK) * 25.4 + 0.5;
-              height_mm = (mode->height / DPI_FALLBACK) * 25.4 + 0.5;
-
-              meta_error_trap_push (meta_get_display ());
-              XRRSetScreenSize (manager_xrandr->xdisplay,
-                                DefaultRootWindow (manager_xrandr->xdisplay),
-                                mode->width, mode->height,
-                                width_mm, height_mm);
-              meta_error_trap_pop (meta_get_display ());
-
-              // The screen size will be updated on the next RRScreenChangeNotify,
-              // but we need the UI to update ASAP.
-              XSync (manager_xrandr->xdisplay, False);
-              manager->screen_width = mode->width;
-              manager->screen_height = mode->height;
-
               meta_error_trap_push (meta_get_display ());
               /* TODO: Send the list of output IDs for this CRTC */
               ok = XRRSetCrtcConfig (manager_xrandr->xdisplay,
@@ -1384,8 +1370,6 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
                                      wl_transform_to_xrandr (output->crtc->transform),
                                      (RROutput *)&output->output_id, 1);
               meta_error_trap_pop (meta_get_display ());
-
-              meta_display_ungrab (meta_get_display ());
 
               if (ok != Success)
                 {
@@ -1403,6 +1387,38 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
               break;
             }
         }
+
+      if (meta_monitor_transform_is_rotated (output->crtc->transform))
+        {
+          screen_width = MAX (screen_width, output->crtc->rect.x + output->crtc->rect.height);
+          screen_height = MAX (screen_height, output->crtc->rect.y + output->crtc->rect.width);
+        }
+      else
+        {
+          screen_width = MAX (screen_width, output->crtc->rect.x + output->crtc->rect.width);
+          screen_height = MAX (screen_height, output->crtc->rect.y + output->crtc->rect.height);
+        }
+    }
+
+  if (screen_width > 0 && screen_height > 0)
+    {
+      width_mm = (screen_width / DPI_FALLBACK) * 25.4 + 0.5;
+      height_mm = (screen_height / DPI_FALLBACK) * 25.4 + 0.5;
+
+      meta_error_trap_push (meta_get_display ());
+      XRRSetScreenSize (manager_xrandr->xdisplay,
+                      DefaultRootWindow (manager_xrandr->xdisplay),
+                      screen_width, screen_height,
+                      width_mm, height_mm);
+      meta_error_trap_pop (meta_get_display ());
+
+      // The screen size will be updated on the next RRScreenChangeNotify,
+      // but we need the UI to update ASAP.
+      XSync (manager_xrandr->xdisplay, False);
+      manager->screen_width = screen_width;
+      manager->screen_height = screen_height;
+
+      meta_display_ungrab (meta_get_display ());
     }
 
   new_config = manager_xrandr->resources->timestamp >=


### PR DESCRIPTION
[endlessm/eos-shell#2785]
