### PR TITLE
Record monitor connect/disconnect events.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ MUTTER_PC_MODULES="
    cogl-1.0 >= 1.15.6
    upower-glib > 0.9.11
    gnome-desktop-3.0
+   eosmetrics-0
 "
 
 GLIB_GSETTINGS


### PR DESCRIPTION
Each time we receive an XEvent we diff the list of currently connected
monitors with the list of previously connected monitors. Any
differences are recorded using the event recorder API. It is possible
that there will be no differences to record because XEvents are sent
for more events than just monitor connects and disconnects.

[endlessm/eos-sdk#635]
