### PR TITLE
monitor-xrandr: don't make configuration persistent immediately

### DIFF
--- a/src/core/monitor-xrandr.c
+++ b/src/core/monitor-xrandr.c
@@ -1268,15 +1268,11 @@ meta_monitor_manager_xrandr_set_crtc_gamma (MetaMonitorManager *manager,
 }
 
 static void
-meta_monitor_manager_xrandr_rebuild_derived (MetaMonitorManager *manager,
-                                             gboolean            persistent)
+meta_monitor_manager_xrandr_rebuild_derived (MetaMonitorManager *manager)
 {
   /* This will be a no-op if the change was from our side, as
      we already called it in the DBus method handler */
   meta_monitor_config_update_current (manager->config, manager);
-
-  if (persistent)
-    meta_monitor_config_make_persistent (manager->config);
 
   meta_monitor_manager_rebuild_derived (manager);
 }
@@ -1415,7 +1411,7 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
          a new preferred mode on hotplug events to handle dynamic
          guest resizing. */
       if (new_config || needs_update)
-        meta_monitor_manager_xrandr_rebuild_derived (manager, needs_update);
+        meta_monitor_manager_xrandr_rebuild_derived (manager);
       else
         meta_monitor_config_make_default (manager->config, manager);
     }
@@ -1435,7 +1431,7 @@ meta_monitor_manager_xrandr_handle_xevent (MetaMonitorManager *manager,
       if (new_config ||
           meta_monitor_config_match_current (manager->config, manager) ||
           needs_update)
-        meta_monitor_manager_xrandr_rebuild_derived (manager, needs_update);
+        meta_monitor_manager_xrandr_rebuild_derived (manager);
       else if (!meta_monitor_config_apply_stored (manager->config, manager))
         meta_monitor_config_make_default (manager->config, manager);
     }


### PR DESCRIPTION
Or we'll fail to restore the previous configuration later. This is only
happening in the overscan toggle code path, because code forces a
persistent configuration change there.

[endlessm/eos-shell#3020]
