### PR TITLE
Switch to using ClutterStage::after-paint

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -636,10 +636,8 @@ meta_compositor_manage_screen (MetaCompositor *compositor,
 
   info->stage = clutter_stage_new ();
 
-  clutter_stage_set_paint_callback (CLUTTER_STAGE (info->stage),
-                                    after_stage_paint,
-                                    info,
-                                    NULL);
+  g_signal_connect (CLUTTER_STAGE (info->stage), "after-paint",
+                    G_CALLBACK (after_stage_paint), info);
 
   clutter_stage_set_sync_delay (CLUTTER_STAGE (info->stage), META_SYNC_DELAY);
 


### PR DESCRIPTION
The experimental API clutter_stage_set_paint_callback() is replaced
with an ::after-paint signal as of Clutter 1.19.5.

https://github.com/endlessm/eos-shell/issues/4788