### PR TITLE
ui: Adapt to GtkStyleContext changes

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -3634,7 +3634,6 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
   GdkRGBA color;
 
   cairo_save (cr);
-  gtk_style_context_save (style_gtk);
 
   cairo_set_line_width (cr, 1.0);
 
@@ -4091,7 +4090,6 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
     }
 
   cairo_restore (cr);
-  gtk_style_context_restore (style_gtk);
 }
 
 void


### PR DESCRIPTION
Since GTK+ commit 3a337156d11a86c7, save()/restore() may only be
used for subelements; in this particular case, the change broke
the backdrop state in decorations. Luckily we don't actually need
the save()/restore() pair anyway, as we only touch the context's
state and always set it explicitly.

[endlessm/eos-shell#5205]