### PR TITLE
window-x11: Fizzle out changes to the three different regions

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -7734,6 +7734,9 @@ void
 meta_window_set_opaque_region (MetaWindow     *window,
                                cairo_region_t *region)
 {
+  if (cairo_region_equal (window->opaque_region, region))
+    return;
+
   g_clear_pointer (&window->opaque_region, cairo_region_destroy);
 
   if (region != NULL)
@@ -7820,6 +7823,9 @@ void
 meta_window_set_shape_region (MetaWindow     *window,
                               cairo_region_t *region)
 {
+  if (cairo_region_equal (window->shape_region, region))
+    return;
+
   g_clear_pointer (&window->shape_region, cairo_region_destroy);
 
   if (region != NULL)
@@ -7905,6 +7911,9 @@ void
 meta_window_set_input_region (MetaWindow     *window,
                               cairo_region_t *region)
 {
+  if (cairo_region_equal (window->input_region, region))
+    return;
+
   g_clear_pointer (&window->input_region, cairo_region_destroy);
 
   if (region != NULL)


### PR DESCRIPTION
GTK+ likes to set these, well, _NET_WM_OPAQUE_REGION in particular, to
the same value. Save some expensive and processing when this happens. We
should probably make GTK+ smarter.

Conflicts:
	src/x11/window-x11.c

[endlessm/eos-shell#5708]