### PR TITLE
window-actor: consider fully opaque ARGB32 windows for unredirection

### DIFF
--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -1428,7 +1428,9 @@ meta_window_actor_should_unredirect (MetaWindowActor *self)
   if (metaWindow->shape_region != NULL)
     return FALSE;
 
-  if (priv->argb32 && !meta_window_requested_bypass_compositor (metaWindow))
+  if (priv->argb32 &&
+      !cairo_region_equal (priv->shape_region, priv->opaque_region) &&
+      !meta_window_requested_bypass_compositor (metaWindow))
     return FALSE;
 
   if (!meta_window_is_monitor_sized (metaWindow))


### PR DESCRIPTION
Totem does full damage and it would be nice to unredirect it at
fullscreen.

We don't consider it because it is an ARGB32 window, however it should
be fine to unredirect given that it is fully opaque. Adjust the logic
with this consideration in mind.

[endlessm/eos-shell#6289]