### PR TITLE
MonitorManager: Check pointer before dereferencing

### DIFF
--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -1780,7 +1780,7 @@ meta_output_is_underscan_compatible (MetaOutput *output)
   if (!g_str_has_prefix (get_connector_type_name (output->connector_type), "HDMI"))
     return FALSE;
 
-  if (!output->crtc)
+  if (!output->crtc || !output->crtc->current_mode)
     return FALSE;
 
   return is_hdtv_resolution (output->crtc->current_mode->width, output->crtc->current_mode->height);


### PR DESCRIPTION
The mode might not be set at this point, so output->crtc->current_mode
will be NULL.

https://phabricator.endlessm.com/T12266