### PR TITLE
monitor-manager: Evaluate adjusted value for overscan whitelist

### DIFF
--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -1777,13 +1777,26 @@ is_hdtv_resolution (guint width,
 gboolean
 meta_output_is_underscan_compatible (MetaOutput *output)
 {
+  guint overscan_width, overscan_height;
+  guint width, height;
+
   if (!g_str_has_prefix (get_connector_type_name (output->connector_type), "HDMI"))
     return FALSE;
 
   if (!output->crtc || !output->crtc->current_mode)
     return FALSE;
 
-  return is_hdtv_resolution (output->crtc->current_mode->width, output->crtc->current_mode->height);
+  /*
+   * Since we can't rely on output->is_overscanned being updated, simply check
+   * both the current and the adjusted values to see if any of them match the
+   * whitelisted values
+   */
+  width = output->crtc->current_mode->width;
+  height = output->crtc->current_mode->height;
+  overscan_width = width / (1 - 2 * OVERSCAN_COMPENSATION_BORDER);
+  overscan_height = height / (1 - 2 * OVERSCAN_COMPENSATION_BORDER);
+
+  return is_hdtv_resolution (width, height) || is_hdtv_resolution (overscan_width, overscan_height);
 }
 
 void


### PR DESCRIPTION
When evaluating the output width and height, only the currently applied
values are considered. This poses a problem for when the overscanned
output reports a different size without the compensation borders.

Also, appearently, we cannot rely on the is_overscanned value to be
updated, since changing the XRandr property triggers multiple apply &
read cycles.

To fix the issue, a simpler approach was taken: simply check if either
the current monitor size or the overscan-adjusted monitor size match
any of the whitelisted sizes.

https://phabricator.endlessm.com/T13812