### PR TITLE
backends: Add flags to MetaMonitorMode

### DIFF
--- a/src/backends/meta-monitor-manager-private.h
+++ b/src/backends/meta-monitor-manager-private.h
@@ -201,6 +201,7 @@ struct _MetaMonitorMode
   int width;
   int height;
   float refresh_rate;
+  guint32 flags;
 
   gpointer driver_private;
   GDestroyNotify driver_notify;

--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -756,7 +756,7 @@ meta_monitor_manager_handle_get_resources (MetaDBusDisplayConfig *skeleton,
 
   g_variant_builder_init (&crtc_builder, G_VARIANT_TYPE ("a(uxiiiiiuaua{sv})"));
   g_variant_builder_init (&output_builder, G_VARIANT_TYPE ("a(uxiausauaua{sv})"));
-  g_variant_builder_init (&mode_builder, G_VARIANT_TYPE ("a(usxuud)"));
+  g_variant_builder_init (&mode_builder, G_VARIANT_TYPE ("a(usxuudu)"));
 
   for (i = 0; i < manager->n_crtcs; i++)
     {
@@ -880,13 +880,14 @@ meta_monitor_manager_handle_get_resources (MetaDBusDisplayConfig *skeleton,
     {
       MetaMonitorMode *mode = &manager->modes[i];
 
-      g_variant_builder_add (&mode_builder, "(usxuud)",
+      g_variant_builder_add (&mode_builder, "(usxuudu)",
                              i, /* ID */
                              mode->name,
                              (gint64)mode->mode_id,
                              (guint32)mode->width,
                              (guint32)mode->height,
-                             (double)mode->refresh_rate);
+                             (double)mode->refresh_rate,
+                             (guint32)mode->flags);
     }
 
   meta_dbus_display_config_complete_get_resources (skeleton,

--- a/src/backends/native/meta-monitor-manager-kms.c
+++ b/src/backends/native/meta-monitor-manager-kms.c
@@ -632,6 +632,7 @@ meta_monitor_manager_kms_read_current (MetaMonitorManager *manager)
       meta_mode->name = g_strndup (mode->name, DRM_DISPLAY_MODE_LEN);
       meta_mode->width = mode->hdisplay;
       meta_mode->height = mode->vdisplay;
+      meta_mode->flags = mode->flags;
 
       /* Calculate refresh rate in milliHz first for extra precision. */
       meta_mode->refresh_rate = (mode->clock * 1000000LL) / mode->htotal;

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -847,6 +847,7 @@ meta_monitor_manager_xrandr_read_current (MetaMonitorManager *manager)
       mode->height = xmode->height;
       mode->refresh_rate = (xmode->dotClock /
 			    ((float)xmode->hTotal * xmode->vTotal));
+      mode->flags = xmode->modeFlags;
       mode->name = get_xmode_name (xmode);
     }
 

--- a/src/org.gnome.Mutter.DisplayConfig.xml
+++ b/src/org.gnome.Mutter.DisplayConfig.xml
@@ -116,6 +116,7 @@
 	* x winsys_id: the low-level ID of this mode
 	* u width, height: the resolution
 	* d frequency: refresh rate
+	* u flags: mode flags as defined in xf86drmMode.h and randr.h
 
         Output and modes are read-only objects (except for output properties),
 	they can change only in accordance to HW changes (such as hotplugging
@@ -134,7 +135,7 @@
       <arg name="serial" direction="out" type="u" />
       <arg name="crtcs" direction="out" type="a(uxiiiiiuaua{sv})" />
       <arg name="outputs" direction="out" type="a(uxiausauaua{sv})" />
-      <arg name="modes" direction="out" type="a(usxuud)" />
+      <arg name="modes" direction="out" type="a(usxuudu)" />
       <arg name="max_screen_width" direction="out" type="i" />
       <arg name="max_screen_height" direction="out" type="i" />
     </method>


### PR DESCRIPTION
And export them in the DBus API since they're useful for
gnome-control-center.

https://bugzilla.gnome.org/show_bug.cgi?id=763832

https://phabricator.endlessm.com/T16337