### PR TITLE
compositor: Expose backface culling to library consumers

### DIFF
--- a/src/compositor/meta-shadow-factory.c
+++ b/src/compositor/meta-shadow-factory.c
@@ -379,6 +379,15 @@ meta_shadow_get_bounds  (MetaShadow            *shadow,
   bounds->height = window_height + shadow->outer_border_top + shadow->outer_border_bottom;
 }
 
+void
+meta_shadow_set_cull_back_face (MetaShadow *shadow,
+                                gboolean   cull)
+{
+  cogl_pipeline_set_cull_face_mode (shadow->pipeline,
+                                    cull ? COGL_PIPELINE_CULL_FACE_MODE_BACK :
+                                           COGL_PIPELINE_CULL_FACE_MODE_NONE);
+}
+
 static void
 meta_shadow_class_info_free (MetaShadowClassInfo *class_info)
 {

--- a/src/compositor/meta-shaped-texture.c
+++ b/src/compositor/meta-shaped-texture.c
@@ -88,6 +88,8 @@ struct _MetaShapedTexturePrivate
   guint tex_width, tex_height;
   guint fallback_width, fallback_height;
 
+  CoglPipelineCullFaceMode cull_mode;
+
   guint create_mipmaps : 1;
 };
 
@@ -125,6 +127,7 @@ meta_shaped_texture_init (MetaShapedTexture *self)
 
   priv->texture = NULL;
   priv->mask_texture = NULL;
+  priv->cull_mode = COGL_PIPELINE_CULL_FACE_MODE_NONE;
   priv->create_mipmaps = TRUE;
 }
 
@@ -442,6 +445,7 @@ meta_shaped_texture_paint (ClutterActor *actor)
           opaque_pipeline = get_unblended_pipeline (ctx);
           cogl_pipeline_set_layer_texture (opaque_pipeline, 0, paint_tex);
           cogl_pipeline_set_layer_filters (opaque_pipeline, 0, filter, filter);
+          cogl_pipeline_set_cull_face_mode (opaque_pipeline, priv->cull_mode);
 
           n_rects = cairo_region_num_rectangles (region);
           for (i = 0; i < n_rects; i++)
@@ -482,6 +486,7 @@ meta_shaped_texture_paint (ClutterActor *actor)
 
       cogl_pipeline_set_layer_texture (blended_pipeline, 0, paint_tex);
       cogl_pipeline_set_layer_filters (blended_pipeline, 0, filter, filter);
+      cogl_pipeline_set_cull_face_mode (blended_pipeline, priv->cull_mode);
 
       CoglColor color;
       cogl_color_init_from_4ub (&color, opacity, opacity, opacity, opacity);
@@ -904,6 +909,16 @@ meta_shaped_texture_set_fallback_size (MetaShapedTexture *self,
 
   priv->fallback_width = fallback_width;
   priv->fallback_height = fallback_height;
+}
+
+void
+meta_shaped_texture_set_cull_back_face (MetaShapedTexture *self,
+                                        gboolean          cull)
+{
+  g_return_if_fail (META_IS_SHAPED_TEXTURE (self));
+
+  self->priv->cull_mode = cull ? COGL_PIPELINE_CULL_FACE_MODE_BACK :
+                                 COGL_PIPELINE_CULL_FACE_MODE_NONE;
 }
 
 static void

--- a/src/compositor/meta-surface-actor.c
+++ b/src/compositor/meta-surface-actor.c
@@ -373,6 +373,15 @@ meta_surface_actor_is_unredirected (MetaSurfaceActor *self)
   return META_SURFACE_ACTOR_GET_CLASS (self)->is_unredirected (self);
 }
 
+void
+meta_surface_actor_set_cull_back_face (MetaSurfaceActor *self,
+                                       gboolean         cull)
+{
+  g_return_if_fail (META_IS_SURFACE_ACTOR (self));
+
+  meta_shaped_texture_set_cull_back_face (self->priv->texture, cull);
+}
+
 MetaWindow *
 meta_surface_actor_get_window (MetaSurfaceActor *self)
 {

--- a/src/compositor/meta-surface-actor.h
+++ b/src/compositor/meta-surface-actor.h
@@ -76,6 +76,9 @@ void meta_surface_actor_set_unredirected (MetaSurfaceActor *actor,
                                           gboolean          unredirected);
 gboolean meta_surface_actor_is_unredirected (MetaSurfaceActor *actor);
 
+void meta_surface_actor_set_cull_back_face (MetaSurfaceActor *actor,
+                                            gboolean         cull);
+
 G_END_DECLS
 
 #endif /* META_SURFACE_ACTOR_PRIVATE_H */

--- a/src/compositor/meta-window-actor.c
+++ b/src/compositor/meta-window-actor.c
@@ -2185,6 +2185,22 @@ meta_window_actor_update_opacity (MetaWindowActor *self)
     clutter_actor_set_opacity (CLUTTER_ACTOR (priv->surface), window->opacity);
 }
 
+void
+meta_window_actor_set_cull_back_face (MetaWindowActor *self,
+                                      gboolean        cull)
+{
+  g_return_if_fail (META_IS_WINDOW_ACTOR (self));
+
+  if (self->priv->surface)
+    meta_surface_actor_set_cull_back_face (self->priv->surface, cull);
+
+  if (self->priv->focused_shadow)
+    meta_shadow_set_cull_back_face (self->priv->focused_shadow, cull);
+
+  if (self->priv->unfocused_shadow)
+    meta_shadow_set_cull_back_face (self->priv->unfocused_shadow, cull);
+}
+
 static void
 meta_window_actor_set_updates_frozen (MetaWindowActor *self,
                                       gboolean         updates_frozen)

--- a/src/meta/meta-shadow-factory.h
+++ b/src/meta/meta-shadow-factory.h
@@ -110,6 +110,9 @@ void        meta_shadow_get_bounds  (MetaShadow            *shadow,
                                      int                    window_height,
                                      cairo_rectangle_int_t *bounds);
 
+void        meta_shadow_set_cull_back_face (MetaShadow *shadow,
+                                            gboolean   cull);
+
 MetaShadowFactory *meta_shadow_factory_new (void);
 
 MetaShadow *meta_shadow_factory_get_shadow (MetaShadowFactory *factory,

--- a/src/meta/meta-shaped-texture.h
+++ b/src/meta/meta-shaped-texture.h
@@ -81,6 +81,9 @@ void meta_shaped_texture_set_opaque_region (MetaShapedTexture *stex,
 cairo_surface_t * meta_shaped_texture_get_image (MetaShapedTexture     *stex,
                                                  cairo_rectangle_int_t *clip);
 
+void meta_shaped_texture_set_cull_back_face (MetaShapedTexture *stex,
+                                             gboolean          cull);
+
 G_END_DECLS
 
 #endif /* __META_SHAPED_TEXTURE_H__ */

--- a/src/meta/meta-window-actor.h
+++ b/src/meta/meta-window-actor.h
@@ -62,6 +62,8 @@ MetaWindow *       meta_window_actor_get_meta_window      (MetaWindowActor *self
 ClutterActor *     meta_window_actor_get_texture          (MetaWindowActor *self);
 void               meta_window_actor_sync_visibility      (MetaWindowActor *self);
 gboolean       meta_window_actor_is_destroyed (MetaWindowActor *self);
+void               meta_window_actor_set_cull_back_face   (MetaWindowActor *self,
+                                                           gboolean        cull);
 
 typedef enum {
   META_SHADOW_MODE_AUTO,


### PR DESCRIPTION
This is almost certainly the wrong place to put this, but it
seems that there isn't any sort of framework available for
library consumers to tweak a window's render pipeline. All
the effects that apply to windows are effectively implemented
in terms of ClutterOffscreenEffect.

We shouldn't have to use ClutterOffscreenEffect for something
as simple as this, so don't.

https://phabricator.endlessm.com/T16637