### PR TITLE
Fix the build for 32 bit systems enabling the GLESv2 driver

### DIFF
--- a/clutter/clutter/evdev/clutter-virtual-input-device-evdev.c
+++ b/clutter/clutter/evdev/clutter-virtual-input-device-evdev.c
@@ -34,6 +34,11 @@
 #include "evdev/clutter-seat-evdev.h"
 #include "evdev/clutter-virtual-input-device-evdev.h"
 
+/* KEY_KBDINPUTASSIST_CANCEL is not defined in older kernels */
+#ifndef KEY_KBDINPUTASSIST_CANCEL
+#define KEY_KBDINPUTASSIST_CANCEL 0x265
+#endif
+
 enum
 {
   PROP_0,

--- a/cogl/cogl/cogl-context.c
+++ b/cogl/cogl/cogl-context.c
@@ -81,6 +81,19 @@
 #define GL_PURGED_CONTEXT_RESET_NV 0x92BB
 #endif
 
+/* These aren't defined in the GLES2 headers */
+#ifndef GL_GUILTY_CONTEXT_RESET_ARB
+#define GL_GUILTY_CONTEXT_RESET_ARB 0x8253
+#endif
+
+#ifndef GL_INNOCENT_CONTEXT_RESET_ARB
+#define GL_INNOCENT_CONTEXT_RESET_ARB 0x8254
+#endif
+
+#ifndef GL_UNKNOWN_CONTEXT_RESET_ARB
+#define GL_UNKNOWN_CONTEXT_RESET_ARB 0x8255
+#endif
+
 static void _cogl_context_free (CoglContext *context);
 
 COGL_OBJECT_DEFINE (Context, context);

--- a/cogl/cogl/cogl-mutter.h
+++ b/cogl/cogl/cogl-mutter.h
@@ -42,7 +42,7 @@
 #include <cogl/winsys/cogl-winsys-egl-private.h>
 #include <cogl/winsys/cogl-winsys-private.h>
 
-void cogl_renderer_set_custom_winsys (CoglRenderer          *renderer,
-                                      CoglWinsysVtableGetter winsys_vtable_getter);
+void cogl_renderer_set_custom_winsys (CoglRenderer                *renderer,
+                                      CoglCustomWinsysVtableGetter winsys_vtable_getter);
 
 #endif /* __COGL_MUTTER_H___ */

--- a/cogl/cogl/cogl-renderer-private.h
+++ b/cogl/cogl/cogl-renderer-private.h
@@ -39,11 +39,12 @@
 #include "cogl-texture-driver.h"
 #include "cogl-context.h"
 #include "cogl-closure-list-private.h"
-#include "cogl-mutter.h"
 
 #ifdef COGL_HAS_XLIB_SUPPORT
 #include <X11/Xlib.h>
 #endif
+
+typedef const CoglWinsysVtable *(*CoglCustomWinsysVtableGetter) (CoglRenderer *renderer);
 
 struct _CoglRenderer
 {
@@ -53,7 +54,7 @@ struct _CoglRenderer
   const CoglDriverVtable *driver_vtable;
   const CoglTextureDriver *texture_driver;
   const CoglWinsysVtable *winsys_vtable;
-  CoglWinsysVtableGetter custom_winsys_vtable_getter;
+  CoglCustomWinsysVtableGetter custom_winsys_vtable_getter;
   CoglWinsysID winsys_id_override;
   GList *constraints;
 

--- a/cogl/cogl/cogl-renderer.c
+++ b/cogl/cogl/cogl-renderer.c
@@ -555,7 +555,7 @@ _cogl_renderer_choose_driver (CoglRenderer *renderer,
 
 void
 cogl_renderer_set_custom_winsys (CoglRenderer          *renderer,
-                                 CoglWinsysVtableGetter winsys_vtable_getter)
+                                 CoglCustomWinsysVtableGetter winsys_vtable_getter)
 {
   renderer->custom_winsys_vtable_getter = winsys_vtable_getter;
 }
@@ -564,10 +564,11 @@ static CoglBool
 connect_custom_winsys (CoglRenderer *renderer,
                        CoglError   **error)
 {
-  const CoglWinsysVtable *winsys = renderer->custom_winsys_vtable_getter();
+  const CoglWinsysVtable *winsys;
   CoglError *tmp_error = NULL;
   GString *error_message;
 
+  winsys = renderer->custom_winsys_vtable_getter (renderer);
   renderer->winsys_vtable = winsys;
 
   error_message = g_string_new ("");

--- a/cogl/cogl/driver/gl/cogl-util-gl-private.h
+++ b/cogl/cogl/driver/gl/cogl-util-gl-private.h
@@ -37,6 +37,11 @@
 #include "cogl-gl-header.h"
 #include "cogl-texture.h"
 
+/* In OpenGL ES context, GL_CONTEXT_LOST has a _KHR prefix */
+#ifndef GL_CONTEXT_LOST
+#define GL_CONTEXT_LOST GL_CONTEXT_LOST_KHR
+#endif
+
 #ifdef COGL_GL_DEBUG
 
 const char *

--- a/cogl/configure.ac
+++ b/cogl/configure.ac
@@ -73,7 +73,7 @@ dnl ================================================================
 #
 # Possible status values are: git, snapshot or release
 #
-m4_define([cogl_release_status], [git])
+m4_define([cogl_release_status], [release])
 
 AC_INIT(cogl, [cogl_1_version])
 AC_CONFIG_SRCDIR(cogl/cogl.h)

--- a/configure.ac
+++ b/configure.ac
@@ -380,6 +380,17 @@ AC_CHECK_DECL([GL_EXT_x11_sync_object],
 
 AC_PATH_PROG([CVT],[cvt],[])
 
+AC_ARG_ENABLE(
+  [cogl-gles2],
+  [AC_HELP_STRING([--enable-cogl-gles2],
+                  [Enable libcogl-gles2 frontend api for OpenGL-ES 2.0 (default: no)])],
+  [with_cogl_gles2=$enableval],
+  [with_cogl_gles2=no]
+)
+AS_IF([test "x$with_cogl_gles2" = "xyes"], [
+  AC_DEFINE([WITH_COGL_GLES2],[1],[Define if we're building with Cogl GLES2 support])
+])
+
 #### Warnings (last since -Werror can disturb other tests)
 
 # Stay command-line compatible with the gnome-common configure option. Here
@@ -479,6 +490,7 @@ mutter-$VERSION
 	Session management:       ${found_sm}
 	Wayland:                  ${have_wayland}
 	Native (KMS) backend:     ${have_native_backend}
+	With Cogl-GLES2 support   ${with_cogl_gles2}
 "
 
 

--- a/src/backends/native/meta-renderer-native.c
+++ b/src/backends/native/meta-renderer-native.c
@@ -1061,7 +1061,7 @@ meta_renderer_native_set_legacy_view_size (MetaRendererNative *renderer_native,
 }
 
 static const CoglWinsysVtable *
-get_native_cogl_winsys_vtable (void)
+get_native_cogl_winsys_vtable (CoglRenderer *cogl_renderer)
 {
   static CoglBool vtable_inited = FALSE;
   static CoglWinsysVtable vtable;

--- a/src/backends/x11/meta-renderer-x11.c
+++ b/src/backends/x11/meta-renderer-x11.c
@@ -47,12 +47,25 @@ struct _MetaRendererX11
 G_DEFINE_TYPE (MetaRendererX11, meta_renderer_x11, META_TYPE_RENDERER)
 
 static const CoglWinsysVtable *
-get_x11_cogl_winsys_vtable (void)
+get_x11_cogl_winsys_vtable (CoglRenderer *renderer)
 {
   if (meta_is_wayland_compositor ())
     return _cogl_winsys_egl_xlib_get_vtable ();
-  else
-    return _cogl_winsys_glx_get_vtable ();
+
+  switch (renderer->driver)
+    {
+    case COGL_DRIVER_GLES1:
+    case COGL_DRIVER_GLES2:
+      return _cogl_winsys_egl_xlib_get_vtable ();
+    case COGL_DRIVER_GL:
+    case COGL_DRIVER_GL3:
+      return _cogl_winsys_glx_get_vtable ();
+    case COGL_DRIVER_ANY:
+    case COGL_DRIVER_NOP:
+    case COGL_DRIVER_WEBGL:
+      break;
+    }
+  g_assert_not_reached ();
 }
 
 static CoglRenderer *

--- a/src/backends/x11/meta-renderer-x11.c
+++ b/src/backends/x11/meta-renderer-x11.c
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 
 #include "clutter/x11/clutter-x11.h"
+#include "cogl/cogl-mutter-config.h"
 #include "cogl/cogl.h"
 #include "cogl/cogl-xlib.h"
 #include "cogl/winsys/cogl-winsys-glx-private.h"
@@ -49,8 +50,10 @@ G_DEFINE_TYPE (MetaRendererX11, meta_renderer_x11, META_TYPE_RENDERER)
 static const CoglWinsysVtable *
 get_x11_cogl_winsys_vtable (CoglRenderer *renderer)
 {
+#ifdef HAVE_WAYLAND
   if (meta_is_wayland_compositor ())
     return _cogl_winsys_egl_xlib_get_vtable ();
+#endif
 
   switch (renderer->driver)
     {
@@ -59,7 +62,9 @@ get_x11_cogl_winsys_vtable (CoglRenderer *renderer)
       return _cogl_winsys_egl_xlib_get_vtable ();
     case COGL_DRIVER_GL:
     case COGL_DRIVER_GL3:
+#if HAVE_COGL_GL
       return _cogl_winsys_glx_get_vtable ();
+#endif
     case COGL_DRIVER_ANY:
     case COGL_DRIVER_NOP:
     case COGL_DRIVER_WEBGL:


### PR DESCRIPTION
As it was explained more in depth in https://bugzilla.gnome.org/show_bug.cgi?id=781467, changes were needed to get mutter to compile for our 32 bit ARM platform, where we enable the GLESv2 driver.

The changes in this PR includes:
  * 2 commit already landed upstream (tokens for the ARB_Robustness extension, CONTEXT_LOST)
  * 1 commit from Jonas not to use GLX when using GLES as a baseline to apply my own patches on top
  * 1 commit from to allow disabling the synchronization ring when building with the GLESv2 driver
  * 2 small commits to fix the build 
  * 1 commit to disable debug symbols in the in-tree version of Cogl (very expensive, specially on GLES)

https://phabricator.endlessm.com/T16599