### PR TITLE
Move mutter-restart-helper back to the mutter-common package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -109,9 +109,7 @@ Replaces: libmutter0,
           libmutter0e,
           libmutter0f,
           libmutter0g,
-          libmutter0h,
-          mutter-common (<< 3.22.3)
-Breaks: mutter-common (<< 3.22.3)
+          libmutter0h
 Description: window manager library from the Mutter window manager
  Mutter is a small window manager, using GTK+ and Clutter to do
  everything.
@@ -126,9 +124,11 @@ Description: window manager library from the Mutter window manager
 
 Package: mutter-common
 Section: misc
-Architecture: all
+Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}
+Replaces: libmutter0i (<< 3.22.3+dev46)
+Breaks: libmutter0i (<< 3.22.3+dev46)
 Description: shared files for the Mutter window manager
  Mutter is a small window manager, using GTK+ and Clutter to do
  everything.

--- a/debian/control.in
+++ b/debian/control.in
@@ -105,9 +105,7 @@ Replaces: libmutter0,
           libmutter0e,
           libmutter0f,
           libmutter0g,
-          libmutter0h,
-          mutter-common (<< 3.22.3)
-Breaks: mutter-common (<< 3.22.3)
+          libmutter0h
 Description: window manager library from the Mutter window manager
  Mutter is a small window manager, using GTK+ and Clutter to do
  everything.
@@ -122,9 +120,11 @@ Description: window manager library from the Mutter window manager
 
 Package: mutter-common
 Section: misc
-Architecture: all
+Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}
+Replaces: libmutter0i (<< 3.22.3+dev46)
+Breaks: libmutter0i (<< 3.22.3+dev46)
 Description: shared files for the Mutter window manager
  Mutter is a small window manager, using GTK+ and Clutter to do
  everything.

--- a/debian/libmutter0i.install
+++ b/debian/libmutter0i.install
@@ -1,3 +1,2 @@
 usr/lib/*/libmutter.so.*
 usr/lib/*/mutter/*.so
-usr/lib/mutter/mutter-restart-helper

--- a/debian/mutter-common.install
+++ b/debian/mutter-common.install
@@ -3,3 +3,4 @@ usr/share/glib-2.0
 usr/share/locale
 usr/share/man
 usr/share/gnome-control-center
+usr/lib/mutter/mutter-restart-helper


### PR DESCRIPTION
After some internal discussion last week we realized that shipping
this package in the libmutter0i package was wrong, as libmutter*
packages are meant to be parallel installable, and having the helper
there would clearly break this future.

So, to clean things up a little bit, we're moving the helper back
to mutter-common and, as the helper is a binary file, making that
package arch:any, so that we get versions for and Intel and ARM.

Note that we also need to play with Replaces/Breaks rules too, so
that dist-upgrades on development machines will work cleanly too.

https://phabricator.endlessm.com/T17155