### PR TITLE
Update to mutter 3.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mutter (3.24.4-0endless1) eos; urgency=medium
+
+  * New upstream release.
+
+ -- Mario Sanchez Prada <mario@endlessm.com>  Thu, 17 Aug 2017 16:49:29 +0200
+
 mutter (3.22.3-2) unstable; urgency=medium
 
   * debian/patches/clutter-clone-Unset-source-when-source-actor-is-dest.patch

--- a/debian/libmutter0i.install
+++ b/debian/libmutter0i.install
@@ -1,2 +1,2 @@
-usr/lib/*/libmutter.so.*
+usr/lib/*/libmutter-0.so.*
 usr/lib/*/mutter/*.so


### PR DESCRIPTION
There's no debian package yet for mutter 3.24, so we are simply bumping the version and adapting to the new filename of the mutter library here.

https://phabricator.endlessm.com/T18787