### PR TITLE
Don't crash when running in headless mode

### DIFF
--- a/src/backends/meta-monitor-manager-dummy.c
+++ b/src/backends/meta-monitor-manager-dummy.c
@@ -471,6 +471,15 @@ meta_monitor_manager_dummy_apply_monitors_config (MetaMonitorManager *manager,
   GPtrArray *crtc_infos;
   GPtrArray *output_infos;
 
+  if (!config)
+    {
+      manager->screen_width = META_MONITOR_MANAGER_MIN_SCREEN_WIDTH;
+      manager->screen_height = META_MONITOR_MANAGER_MIN_SCREEN_HEIGHT;
+
+      meta_monitor_manager_rebuild (manager, NULL);
+      return TRUE;
+    }
+
   if (!meta_monitor_config_manager_assign (manager, config,
                                            &crtc_infos, &output_infos,
                                            error))

--- a/src/backends/meta-monitor-manager-private.h
+++ b/src/backends/meta-monitor-manager-private.h
@@ -66,6 +66,9 @@ typedef struct _MetaCrtcInfo MetaCrtcInfo;
 typedef struct _MetaOutputInfo MetaOutputInfo;
 typedef struct _MetaTileInfo MetaTileInfo;
 
+#define META_MONITOR_MANAGER_MIN_SCREEN_WIDTH 640
+#define META_MONITOR_MANAGER_MIN_SCREEN_HEIGHT 480
+
 typedef enum
 {
   META_MONITOR_TRANSFORM_NORMAL,

--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -281,7 +281,7 @@ meta_monitor_manager_is_lid_closed (MetaMonitorManager *manager)
 gboolean
 meta_monitor_manager_is_headless (MetaMonitorManager *manager)
 {
-  return !manager->monitors;
+  return !manager->logical_monitors;
 }
 
 static void

--- a/src/backends/meta-monitor.c
+++ b/src/backends/meta-monitor.c
@@ -1176,6 +1176,32 @@ meta_monitor_mode_foreach_crtc (MetaMonitor        *monitor,
     {
       MetaMonitorCrtcMode *monitor_crtc_mode = &mode->crtc_modes[i];
 
+      if (!monitor_crtc_mode->crtc_mode)
+        continue;
+
+      if (!func (monitor, mode, monitor_crtc_mode, user_data, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
+meta_monitor_mode_foreach_output (MetaMonitor        *monitor,
+                                  MetaMonitorMode    *mode,
+                                  MetaMonitorModeFunc func,
+                                  gpointer            user_data,
+                                  GError            **error)
+{
+  MetaMonitorPrivate *monitor_priv =
+    meta_monitor_get_instance_private (monitor);
+  GList *l;
+  int i;
+
+  for (l = monitor_priv->outputs, i = 0; l; l = l->next, i++)
+    {
+      MetaMonitorCrtcMode *monitor_crtc_mode = &mode->crtc_modes[i];
+
       if (!func (monitor, mode, monitor_crtc_mode, user_data, error))
         return FALSE;
     }

--- a/src/backends/meta-monitor.h
+++ b/src/backends/meta-monitor.h
@@ -157,6 +157,12 @@ gboolean meta_monitor_mode_foreach_crtc (MetaMonitor        *monitor,
                                          gpointer            user_data,
                                          GError            **error);
 
+gboolean meta_monitor_mode_foreach_output (MetaMonitor        *monitor,
+                                           MetaMonitorMode    *mode,
+                                           MetaMonitorModeFunc func,
+                                           gpointer            user_data,
+                                           GError            **error);
+
 MetaMonitorSpec * meta_monitor_spec_clone (MetaMonitorSpec *monitor_id);
 
 gboolean meta_monitor_spec_equals (MetaMonitorSpec *monitor_id,

--- a/src/backends/native/meta-monitor-manager-kms.c
+++ b/src/backends/native/meta-monitor-manager-kms.c
@@ -1510,8 +1510,9 @@ meta_monitor_manager_kms_apply_monitors_config (MetaMonitorManager *manager,
 
   if (!config)
     {
-      manager->screen_width = 0;
-      manager->screen_height = 0;
+      manager->screen_width = META_MONITOR_MANAGER_MIN_SCREEN_WIDTH;
+      manager->screen_height = META_MONITOR_MANAGER_MIN_SCREEN_HEIGHT;
+      meta_monitor_manager_rebuild (manager, NULL);
       return TRUE;
     }
 

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1555,7 +1555,7 @@ meta_screen_get_primary_monitor (MetaScreen *screen)
   if (logical_monitor)
     return logical_monitor->number;
   else
-    return 0;
+    return -1;
 }
 
 /**

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3601,22 +3601,26 @@ meta_window_update_for_monitors_changed (MetaWindow *window)
   if (!new)
     new = meta_monitor_manager_get_primary_logical_monitor (monitor_manager);
 
-  if (!new)
-    return;
+  if (new && old)
+    {
+      if (window->tile_mode != META_TILE_NONE)
+        window->tile_monitor_number = new->number;
 
-  if (window->tile_mode != META_TILE_NONE)
-    window->tile_monitor_number = new->number;
-
-  /* This will eventually reach meta_window_update_monitor that
-   * will send leave/enter-monitor events. The old != new monitor
-   * check will always fail (due to the new logical_monitors set) so
-   * we will always send the events, even if the new and old monitor
-   * index is the same. That is right, since the enumeration of the
-   * monitors changed and the same index could be refereing
-   * to a different monitor. */
-  meta_window_move_between_rects (window,
-                                  &old->rect,
-                                  &new->rect);
+      /* This will eventually reach meta_window_update_monitor that
+       * will send leave/enter-monitor events. The old != new monitor
+       * check will always fail (due to the new logical_monitors set) so
+       * we will always send the events, even if the new and old monitor
+       * index is the same. That is right, since the enumeration of the
+       * monitors changed and the same index could be refereing
+       * to a different monitor. */
+      meta_window_move_between_rects (window,
+                                      &old->rect,
+                                      &new->rect);
+    }
+  else
+    {
+      meta_window_update_monitor (window, FALSE);
+    }
 }
 
 void
@@ -3679,7 +3683,6 @@ meta_window_move_resize_internal (MetaWindow          *window,
    */
 
   gboolean did_placement;
-  guint old_output_winsys_id;
   MetaRectangle unconstrained_rect;
   MetaRectangle constrained_rect;
   MetaMoveResizeResultFlags result = 0;
@@ -3733,7 +3736,8 @@ meta_window_move_resize_internal (MetaWindow          *window,
     g_assert_not_reached ();
 
   constrained_rect = unconstrained_rect;
-  if (flags & (META_MOVE_RESIZE_MOVE_ACTION | META_MOVE_RESIZE_RESIZE_ACTION))
+  if (flags & (META_MOVE_RESIZE_MOVE_ACTION | META_MOVE_RESIZE_RESIZE_ACTION) &&
+      window->monitor)
     {
       MetaRectangle old_rect;
       meta_window_get_frame_rect (window, &old_rect);
@@ -3783,13 +3787,22 @@ meta_window_move_resize_internal (MetaWindow          *window,
                                             did_placement);
     }
 
-  old_output_winsys_id = window->monitor->winsys_id;
+  if (window->monitor)
+    {
+      guint old_output_winsys_id;
 
-  meta_window_update_monitor (window, flags & META_MOVE_RESIZE_USER_ACTION);
+      old_output_winsys_id = window->monitor->winsys_id;
 
-  if (old_output_winsys_id != window->monitor->winsys_id &&
-      flags & META_MOVE_RESIZE_MOVE_ACTION && flags & META_MOVE_RESIZE_USER_ACTION)
-    window->preferred_output_winsys_id = window->monitor->winsys_id;
+      meta_window_update_monitor (window, flags & META_MOVE_RESIZE_USER_ACTION);
+
+      if (old_output_winsys_id != window->monitor->winsys_id &&
+          flags & META_MOVE_RESIZE_MOVE_ACTION && flags & META_MOVE_RESIZE_USER_ACTION)
+        window->preferred_output_winsys_id = window->monitor->winsys_id;
+    }
+  else
+    {
+      meta_window_update_monitor (window, flags & META_MOVE_RESIZE_USER_ACTION);
+    }
 
   if ((result & META_MOVE_RESIZE_RESULT_FRAME_SHAPE_CHANGED) && window->frame_bounds)
     {
@@ -5368,7 +5381,7 @@ meta_window_recalc_features (MetaWindow *window)
       window->has_maximize_func = FALSE;
     }
 
-  if (window->has_maximize_func)
+  if (window->has_maximize_func && window->monitor)
     {
       MetaRectangle work_area, client_rect;
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1060,7 +1060,10 @@ _meta_window_shared_new (MetaDisplay         *display,
   window->compositor_private = NULL;
 
   window->monitor = meta_window_calculate_main_logical_monitor (window);
-  window->preferred_output_winsys_id = window->monitor->winsys_id;
+  if (window->monitor)
+    window->preferred_output_winsys_id = window->monitor->winsys_id;
+  else
+    window->preferred_output_winsys_id = UINT_MAX;
 
   window->tile_match = NULL;
 

--- a/src/tests/monitor-unit-tests.c
+++ b/src/tests/monitor-unit-tests.c
@@ -584,10 +584,10 @@ check_monitor_configuration (MonitorTestCase *test_case)
             .expect_crtc_mode_iter =
               test_case->expect.monitors[i].modes[j].crtc_modes
           };
-          meta_monitor_mode_foreach_crtc (monitor, mode,
-                                          check_monitor_mode,
-                                          &data,
-                                          NULL);
+          meta_monitor_mode_foreach_output (monitor, mode,
+                                            check_monitor_mode,
+                                            &data,
+                                            NULL);
         }
 
       current_mode = meta_monitor_get_current_mode (monitor);
@@ -613,10 +613,10 @@ check_monitor_configuration (MonitorTestCase *test_case)
             .expect_crtc_mode_iter =
               test_case->expect.monitors[i].modes[expected_current_mode_index].crtc_modes
           };
-          meta_monitor_mode_foreach_crtc (monitor, expected_current_mode,
-                                          check_current_monitor_mode,
-                                          &data,
-                                          NULL);
+          meta_monitor_mode_foreach_output (monitor, expected_current_mode,
+                                            check_current_monitor_mode,
+                                            &data,
+                                            NULL);
         }
 
       meta_monitor_derive_current_mode (monitor);


### PR DESCRIPTION
This is a partial backport of the X11-related patches from GNOME bug 730551 (see [1]) that allow running mutter in headless mode (no monitors attached) without crashing. This patches are already part of 3.26 so we will drop them as soon as we rebase on top of that version of the shell.

[1] https://bugzilla.gnome.org/show_bug.cgi?id=730551

https://phabricator.endlessm.com/T19389