### PR TITLE
core: Return -1 if meta_window_get_monitor is called on an unmanaged window

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3528,11 +3528,16 @@ maybe_move_attached_dialog (MetaWindow *window,
  *
  * Gets index of the monitor that this window is on.
  *
- * Return Value: The index of the monitor in the screens monitor list
+ * Return Value: The index of the monitor in the screens monitor list, or -1
+ * if the window has been recently unmanaged and does not have
+ * a monitor.
  */
 int
 meta_window_get_monitor (MetaWindow *window)
 {
+  if (!window->monitor)
+    return -1;
+
   return window->monitor->number;
 }
 


### PR DESCRIPTION
As opposed to crashing. In this case, letting the caller deal with
it is the best policy, since this is public API.

https://bugzilla.gnome.org/show_bug.cgi?id=788834