### PR TITLE
startup-notification: Increase the timout from 15 to 60 seconds

### DIFF
--- a/src/core/startup-notification.c
+++ b/src/core/startup-notification.c
@@ -36,7 +36,7 @@
  * OpenOffice or whatever seems to stop launching - people
  * might decide they need to launch it again.
  */
-#define STARTUP_TIMEOUT 15000000
+#define STARTUP_TIMEOUT 60000000
 
 typedef struct _MetaStartupNotificationSequence MetaStartupNotificationSequence;
 typedef struct _MetaStartupNotificationSequenceClass MetaStartupNotificationSequenceClass;


### PR DESCRIPTION
We currently have some issues with flatpak applications that take
too long to run the first time because of the fontconfig cache being
generated on the fly, which is a process that can take up to 20-30
seconds in a slow machine like the Endless One, thus causing quite
some confusion because of the splash screen disappearing early and
the application showing up later on, once the cache is ready.

To workaround this problem while the fontconfig issue is not entirely
solved, we increase this timeout up to 60 seconds, so that the splash
screen won't be killed too early in those cases as per the startup
notification implementation.

https://phabricator.endlessm.com/T13168