### PR TITLE
Expose human-friendly names for resolution modes

### DIFF
--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -1228,7 +1228,7 @@ request_persistent_confirmation (MetaMonitorManager *manager)
 #define META_DISPLAY_CONFIG_MODE_FLAGS_PREFERRED (1 << 0)
 #define META_DISPLAY_CONFIG_MODE_FLAGS_CURRENT (1 << 1)
 
-#define MODE_FORMAT "(siiddada{sv})"
+#define MODE_FORMAT "(ssiiddada{sv})"
 #define MODES_FORMAT "a" MODE_FORMAT
 #define MONITOR_SPEC_FORMAT "(ssss)"
 #define MONITOR_FORMAT "(" MONITOR_SPEC_FORMAT MODES_FORMAT "a{sv})"
@@ -1278,6 +1278,7 @@ meta_monitor_manager_handle_get_current_state (MetaDBusDisplayConfig *skeleton,
           MetaMonitorMode *monitor_mode = k->data;
           GVariantBuilder supported_scales_builder;
           const char *mode_id;
+          const char *mode_name;
           int mode_width, mode_height;
           float refresh_rate;
           float preferred_scale;
@@ -1287,6 +1288,7 @@ meta_monitor_manager_handle_get_current_state (MetaDBusDisplayConfig *skeleton,
           MetaCrtcModeFlag mode_flags;
 
           mode_id = meta_monitor_mode_get_id (monitor_mode);
+          mode_name = meta_monitor_mode_get_name (monitor_mode);
           meta_monitor_mode_get_resolution (monitor_mode,
                                             &mode_width, &mode_height);
           refresh_rate = meta_monitor_mode_get_refresh_rate (monitor_mode);
@@ -1328,6 +1330,7 @@ meta_monitor_manager_handle_get_current_state (MetaDBusDisplayConfig *skeleton,
 
           g_variant_builder_add (&modes_builder, MODE_FORMAT,
                                  mode_id,
+                                 mode_name,
                                  mode_width,
                                  mode_height,
                                  refresh_rate,

--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -1002,7 +1002,7 @@ meta_monitor_manager_handle_get_resources (MetaDBusDisplayConfig *skeleton,
 
   g_variant_builder_init (&crtc_builder, G_VARIANT_TYPE ("a(uxiiiiiuaua{sv})"));
   g_variant_builder_init (&output_builder, G_VARIANT_TYPE ("a(uxiausauaua{sv})"));
-  g_variant_builder_init (&mode_builder, G_VARIANT_TYPE ("a(usxuudu)"));
+  g_variant_builder_init (&mode_builder, G_VARIANT_TYPE ("a(uxuudu)"));
 
   for (i = 0; i < manager->n_crtcs; i++)
     {
@@ -1126,9 +1126,8 @@ meta_monitor_manager_handle_get_resources (MetaDBusDisplayConfig *skeleton,
     {
       MetaCrtcMode *mode = &manager->modes[i];
 
-      g_variant_builder_add (&mode_builder, "(usxuudu)",
+      g_variant_builder_add (&mode_builder, "(uxuudu)",
                              i, /* ID */
-                             mode->name,
                              (gint64)mode->mode_id,
                              (guint32)mode->width,
                              (guint32)mode->height,

--- a/src/backends/meta-monitor.c
+++ b/src/backends/meta-monitor.c
@@ -37,6 +37,7 @@
 typedef struct _MetaMonitorMode
 {
   char *id;
+  char *name;
   MetaMonitorModeSpec spec;
   MetaMonitorCrtcMode *crtc_modes;
 } MetaMonitorMode;
@@ -439,6 +440,7 @@ meta_monitor_normal_generate_modes (MetaMonitorNormal *monitor_normal)
         .flags = crtc_mode->flags & HANDLED_CRTC_MODE_FLAGS
       },
       mode->id = generate_mode_id (&mode->spec);
+      mode->name = g_strdup (crtc_mode->name);
       mode->crtc_modes = g_new (MetaMonitorCrtcMode, 1);
       mode->crtc_modes[0] = (MetaMonitorCrtcMode) {
         .output = output,
@@ -774,7 +776,7 @@ create_tiled_monitor_mode (MetaMonitorTiled *monitor_tiled,
     .flags = reference_crtc_mode->flags & HANDLED_CRTC_MODE_FLAGS
   };
   mode->parent.id = generate_mode_id (&mode->parent.spec);
-
+  mode->parent.name = g_strdup (mode->parent.name);
   mode->parent.crtc_modes = g_new0 (MetaMonitorCrtcMode,
                                     g_list_length (monitor_priv->outputs));
   for (l = monitor_priv->outputs, i = 0; l; l = l->next, i++)
@@ -889,6 +891,7 @@ create_untiled_monitor_mode (MetaMonitorTiled *monitor_tiled,
     .flags = crtc_mode->flags & HANDLED_CRTC_MODE_FLAGS
   };
   mode->parent.id = generate_mode_id (&mode->parent.spec);
+  mode->parent.name = g_strdup (mode->parent.name);
   mode->parent.crtc_modes = g_new0 (MetaMonitorCrtcMode,
                                     g_list_length (monitor_priv->outputs));
 
@@ -1240,6 +1243,7 @@ static void
 meta_monitor_mode_free (MetaMonitorMode *monitor_mode)
 {
   g_free (monitor_mode->id);
+  g_free (monitor_mode->name);
   g_free (monitor_mode->crtc_modes);
   g_free (monitor_mode);
 }
@@ -1593,6 +1597,12 @@ const char *
 meta_monitor_mode_get_id (MetaMonitorMode *monitor_mode)
 {
   return monitor_mode->id;
+}
+
+const char *
+meta_monitor_mode_get_name (MetaMonitorMode *monitor_mode)
+{
+  return monitor_mode->name;
 }
 
 void

--- a/src/backends/meta-monitor.h
+++ b/src/backends/meta-monitor.h
@@ -183,6 +183,8 @@ float * meta_monitor_calculate_supported_scales (MetaMonitor                *mon
 
 const char * meta_monitor_mode_get_id (MetaMonitorMode *monitor_mode);
 
+const char * meta_monitor_mode_get_name (MetaMonitorMode *monitor_mode);
+
 MetaMonitorModeSpec * meta_monitor_mode_get_spec (MetaMonitorMode *monitor_mode);
 
 void meta_monitor_mode_get_resolution (MetaMonitorMode *monitor_mode,

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -725,12 +725,6 @@ get_xmode_name (XRRModeInfo *xmode)
   int width = xmode->width;
   int height = xmode->height;
 
-  if (xmode->hSkew != 0)
-    {
-      width += 2 * (xmode->hSkew >> 8);
-      height += 2 * (xmode->hSkew & 0xff);
-    }
-
   return g_strdup_printf ("%dx%d", width, height);
 }
 

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -725,6 +725,12 @@ get_xmode_name (XRRModeInfo *xmode)
   int width = xmode->width;
   int height = xmode->height;
 
+  if (xmode->hSkew != 0)
+    {
+      width += 2 * (xmode->hSkew >> 8);
+      height += 2 * (xmode->hSkew & 0xff);
+    }
+
   return g_strdup_printf ("%dx%d", width, height);
 }
 

--- a/src/org.gnome.Mutter.DisplayConfig.xml
+++ b/src/org.gnome.Mutter.DisplayConfig.xml
@@ -112,7 +112,6 @@
 	Multiple outputs in the same CRTCs must all have the same mode.
 	A mode is exposed as:
 	* u ID: the ID in the API
-	* s name: the name, suitable for showing to the user
 	* x winsys_id: the low-level ID of this mode
 	* u width, height: the resolution
 	* d frequency: refresh rate
@@ -135,7 +134,7 @@
       <arg name="serial" direction="out" type="u" />
       <arg name="crtcs" direction="out" type="a(uxiiiiiuaua{sv})" />
       <arg name="outputs" direction="out" type="a(uxiausauaua{sv})" />
-      <arg name="modes" direction="out" type="a(usxuudu)" />
+      <arg name="modes" direction="out" type="a(uxuudu)" />
       <arg name="max_screen_width" direction="out" type="i" />
       <arg name="max_screen_height" direction="out" type="i" />
     </method>

--- a/src/org.gnome.Mutter.DisplayConfig.xml
+++ b/src/org.gnome.Mutter.DisplayConfig.xml
@@ -304,8 +304,9 @@
 	* s vendor: vendor name
 	* s product: product name
 	* s serial: product serial
-	* a(siiddada{sv}) modes: available modes
+	* a(ssiiddada{sv}) modes: available modes
 	    * s id: mode ID
+	    * s name: the name, suitable for showing to the user
 	    * i width: width in physical pixels
 	    * i height: height in physical pixels
 	    * d refresh rate: refresh rate
@@ -397,7 +398,7 @@
     -->
     <method name="GetCurrentState">
       <arg name="serial" direction="out" type="u" />
-      <arg name="monitors" direction="out" type="a((ssss)a(siiddada{sv})a{sv})" />
+      <arg name="monitors" direction="out" type="a((ssss)a(ssiiddada{sv})a{sv})" />
       <arg name="logical_monitors" direction="out" type="a(iiduba(ssss)a{sv})" />
       <arg name="properties" direction="out" type="a{sv}" />
     </method>


### PR DESCRIPTION
We used to do this via the GetResources method in the past, but since 3.26 that's no longer used by its only client (g-c-c), which is now using GetCurrentState instead. Thus, we need to revert our previous patch and implement this in the new place.

https://phabricator.endlessm.com/T20655