### PR TITLE
Bring back support for underscanning in "crop" mode

### DIFF
--- a/src/backends/meta-monitor-config-manager.c
+++ b/src/backends/meta-monitor-config-manager.c
@@ -48,12 +48,6 @@ G_DEFINE_TYPE (MetaMonitorConfigManager, meta_monitor_config_manager,
 G_DEFINE_TYPE (MetaMonitorsConfig, meta_monitors_config,
                G_TYPE_OBJECT)
 
-static void
-meta_crtc_info_free (MetaCrtcInfo *info);
-
-static void
-meta_output_info_free (MetaOutputInfo *info);
-
 MetaMonitorConfigManager *
 meta_monitor_config_manager_new (MetaMonitorManager *monitor_manager)
 {
@@ -1285,14 +1279,14 @@ meta_monitors_config_class_init (MetaMonitorsConfigClass *klass)
   object_class->finalize = meta_monitors_config_finalize;
 }
 
-static void
+void
 meta_crtc_info_free (MetaCrtcInfo *info)
 {
   g_ptr_array_free (info->outputs, TRUE);
   g_slice_free (MetaCrtcInfo, info);
 }
 
-static void
+void
 meta_output_info_free (MetaOutputInfo *info)
 {
   g_slice_free (MetaOutputInfo, info);

--- a/src/backends/meta-monitor-config-manager.h
+++ b/src/backends/meta-monitor-config-manager.h
@@ -140,6 +140,10 @@ MetaMonitorsConfigKey * meta_create_monitors_config_key_for_current_state (MetaM
 gboolean meta_logical_monitor_configs_have_monitor (GList           *logical_monitor_configs,
                                                     MetaMonitorSpec *monitor_spec);
 
+void meta_crtc_info_free (MetaCrtcInfo *info);
+
+void meta_output_info_free (MetaOutputInfo *info);
+
 gboolean meta_verify_monitor_mode_spec (MetaMonitorModeSpec *monitor_mode_spec,
                                         GError             **error);
 

--- a/src/backends/meta-monitor-manager-private.h
+++ b/src/backends/meta-monitor-manager-private.h
@@ -161,6 +161,12 @@ struct _MetaTileInfo
   guint32 tile_h;
 };
 
+/* For now, underscan to 90% of the claimed display size whenever that
+ * option is enabled. In the future there may be a UI to configure this
+ * value.
+ */
+#define OVERSCAN_COMPENSATION_BORDER 0.05
+
 struct _MetaOutput
 {
   /* The CRTC driving this output, NULL if the output is not enabled */

--- a/src/backends/meta-monitor-manager-private.h
+++ b/src/backends/meta-monitor-manager-private.h
@@ -161,11 +161,11 @@ struct _MetaTileInfo
   guint32 tile_h;
 };
 
-/* For now, underscan to 90% of the claimed display size whenever that
+/* For now, underscan to 95% of the claimed display size whenever that
  * option is enabled. In the future there may be a UI to configure this
  * value.
  */
-#define OVERSCAN_COMPENSATION_BORDER 0.05
+#define OVERSCAN_COMPENSATION_BORDER 0.025
 
 struct _MetaOutput
 {

--- a/src/backends/meta-monitor-manager-private.h
+++ b/src/backends/meta-monitor-manager-private.h
@@ -492,6 +492,8 @@ void               meta_output_parse_edid (MetaOutput *output,
                                            GBytes     *edid);
 gboolean           meta_output_is_laptop  (MetaOutput *output);
 
+const char *       meta_output_get_connector_type_name (MetaOutput *output);
+
 gboolean           meta_monitor_manager_has_hotplug_mode_update (MetaMonitorManager *manager);
 void               meta_monitor_manager_read_current_state (MetaMonitorManager *manager);
 void               meta_monitor_manager_on_hotplug (MetaMonitorManager *manager);

--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -1618,6 +1618,7 @@ create_monitor_config_from_variant (MetaMonitorManager *manager,
   MetaMonitor *monitor;
   MetaMonitorSpec *monitor_spec;
   MetaMonitorModeSpec *monitor_mode_spec;
+  MetaOutput *output;
   g_autoptr (GVariant) properties_variant = NULL;
   gboolean enable_underscanning = FALSE;
 
@@ -1642,7 +1643,17 @@ create_monitor_config_from_variant (MetaMonitorManager *manager,
       return NULL;
     }
 
-  g_variant_lookup (properties_variant, "underscanning", "b", &enable_underscanning);
+  output = meta_monitor_get_main_output (monitor);
+  if (g_variant_lookup (properties_variant, "underscanning", "b", &enable_underscanning))
+    {
+      if (enable_underscanning && !output->supports_underscanning)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Underscanning requested but unsupported");
+          return NULL;
+
+        }
+    }
 
   monitor_spec = meta_monitor_spec_clone (meta_monitor_get_spec (monitor));
 

--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -963,10 +963,10 @@ make_display_name (MetaMonitorManager *manager,
     }
 }
 
-static const char *
-get_connector_type_name (MetaConnectorType connector_type)
+const char *
+meta_output_get_connector_type_name (MetaOutput *output)
 {
-  switch (connector_type)
+  switch (output->connector_type)
     {
     case META_CONNECTOR_TYPE_Unknown: return "Unknown";
     case META_CONNECTOR_TYPE_VGA: return "VGA";
@@ -1072,7 +1072,7 @@ meta_monitor_manager_handle_get_resources (MetaDBusDisplayConfig *skeleton,
       g_variant_builder_add (&properties, "{sv}", "presentation",
                              g_variant_new_boolean (output->is_presentation));
       g_variant_builder_add (&properties, "{sv}", "connector-type",
-                             g_variant_new_string (get_connector_type_name (output->connector_type)));
+                             g_variant_new_string (meta_output_get_connector_type_name (output)));
       g_variant_builder_add (&properties, "{sv}", "underscanning",
                              g_variant_new_boolean (output->is_underscanning));
       g_variant_builder_add (&properties, "{sv}", "supports-underscanning",

--- a/src/backends/native/meta-monitor-manager-kms.c
+++ b/src/backends/native/meta-monitor-manager-kms.c
@@ -1234,14 +1234,14 @@ set_underscan (MetaMonitorManagerKms *manager_kms,
 
       if (crtc_kms->underscan_hborder_prop_id)
         {
-          uint64_t value = crtc->current_mode->width * 0.05;
+          uint64_t value = crtc->current_mode->width * OVERSCAN_COMPENSATION_BORDER;
           drmModeObjectSetProperty (manager_kms->fd, crtc->crtc_id,
                                     DRM_MODE_OBJECT_CRTC,
                                     crtc_kms->underscan_hborder_prop_id, value);
         }
       if (crtc_kms->underscan_vborder_prop_id)
         {
-          uint64_t value = crtc->current_mode->height * 0.05;
+          uint64_t value = crtc->current_mode->height * OVERSCAN_COMPENSATION_BORDER;
           drmModeObjectSetProperty (manager_kms->fd, crtc->crtc_id,
                                     DRM_MODE_OBJECT_CRTC,
                                     crtc_kms->underscan_vborder_prop_id, value);

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -86,6 +86,8 @@ G_DEFINE_TYPE (MetaMonitorManagerXrandr, meta_monitor_manager_xrandr, META_TYPE_
 typedef struct _MetaOutputXrandr
 {
   char *underscan_value;
+  int underscan_hborder;
+  int underscan_vborder;
 } MetaOutputXrandr;
 
 #ifdef HAVE_XRANDR15
@@ -259,6 +261,24 @@ output_get_presentation_xrandr (MetaMonitorManagerXrandr *manager_xrandr,
                                 MetaOutput *output)
 {
   return output_get_boolean_property (manager_xrandr, output, "_MUTTER_PRESENTATION_OUTPUT");
+}
+
+static void
+output_get_underscanning_borders_xrandr (MetaMonitorManagerXrandr *manager_xrandr,
+                                         MetaOutput               *output,
+                                         int                      *underscan_hborder,
+                                         int                      *underscan_vborder)
+{
+  int hborder, vborder;
+
+  if (!output_get_integer_property (manager_xrandr, output, "underscan hborder", &hborder))
+    return;
+
+  if (!output_get_integer_property (manager_xrandr, output, "underscan vborder", &vborder))
+    return;
+
+  *underscan_hborder = hborder;
+  *underscan_vborder = vborder;
 }
 
 static gboolean
@@ -942,6 +962,9 @@ meta_monitor_manager_xrandr_read_current (MetaMonitorManager *manager)
 	  output->is_underscanning = output_get_underscanning_xrandr (manager_xrandr, output);
 
 	  output_get_backlight_limits_xrandr (manager_xrandr, output);
+	  output_get_underscanning_borders_xrandr (manager_xrandr, output,
+                                                   &output_xrandr->underscan_hborder,
+                                                   &output_xrandr->underscan_vborder);
 
 	  if (!(output->backlight_min == 0 && output->backlight_max == 0))
 	    output->backlight = output_get_backlight_xrandr (manager_xrandr, output);
@@ -1093,26 +1116,33 @@ output_set_underscanning_xrandr (MetaMonitorManagerXrandr *manager_xrandr,
    * make the border configurable. */
   if (underscanning)
     {
-      uint32_t border_value;
-
-      prop = XInternAtom (manager_xrandr->xdisplay, "underscan hborder", False);
-      border_value = output->crtc->current_mode->width * 0.05;
-
-      xcb_randr_change_output_property (XGetXCBConnection (manager_xrandr->xdisplay),
-                                        (XID)output->winsys_id,
-                                        prop, XCB_ATOM_INTEGER, 32,
-                                        XCB_PROP_MODE_REPLACE,
-                                        1, &border_value);
-
-      prop = XInternAtom (manager_xrandr->xdisplay, "underscan vborder", False);
-      border_value = output->crtc->current_mode->height * 0.05;
-
-      xcb_randr_change_output_property (XGetXCBConnection (manager_xrandr->xdisplay),
-                                        (XID)output->winsys_id,
-                                        prop, XCB_ATOM_INTEGER, 32,
-                                        XCB_PROP_MODE_REPLACE,
-                                        1, &border_value);
+      /* If this function is called again when underscanning is already on,
+       * we don't want to touch the borders.
+       */
+      if (output_xrandr->underscan_hborder == 0)
+        output_xrandr->underscan_hborder = output->crtc->current_mode->width * OVERSCAN_COMPENSATION_BORDER;
+      if (output_xrandr->underscan_vborder == 0)
+        output_xrandr->underscan_vborder = output->crtc->current_mode->height * OVERSCAN_COMPENSATION_BORDER;
     }
+  else
+    {
+      output_xrandr->underscan_hborder = 0;
+      output_xrandr->underscan_vborder = 0;
+    }
+
+  prop = XInternAtom (manager_xrandr->xdisplay, "underscan hborder", False);
+  xcb_randr_change_output_property (XGetXCBConnection (manager_xrandr->xdisplay),
+                                    (XID)output->winsys_id,
+                                    prop, XCB_ATOM_INTEGER, 32,
+                                    XCB_PROP_MODE_REPLACE,
+                                    1, &output_xrandr->underscan_hborder);
+
+  prop = XInternAtom (manager_xrandr->xdisplay, "underscan vborder", False);
+  xcb_randr_change_output_property (XGetXCBConnection (manager_xrandr->xdisplay),
+                                    (XID)output->winsys_id,
+                                    prop, XCB_ATOM_INTEGER, 32,
+                                    XCB_PROP_MODE_REPLACE,
+                                    1, &output_xrandr->underscan_vborder);
 }
 
 static gboolean

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -370,11 +370,11 @@ output_get_supports_underscanning_xrandr (MetaMonitorManagerXrandr *manager_xran
 
   for (i = 0; i < property_info->num_values; i++)
     {
-      /* The output supports underscanning if "on" is a valid value
+      /* The output supports underscanning if "on" or "crop" are valid values
        * for the underscan property.
        */
       char *name = XGetAtomName (manager_xrandr->xdisplay, values[i]);
-      if (strcmp (name, "on") == 0)
+      if (strcmp (name, "on") == 0 || strcmp (name, "crop") == 0)
         {
           supports_underscanning = TRUE;
           if (underscan_value)

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -1505,10 +1505,9 @@ apply_crtc_assignments (MetaMonitorManager *manager,
                                       output_info->output,
                                       output_info->is_presentation);
 
-      if (output_get_supports_underscanning_xrandr (manager_xrandr, output_info->output, NULL))
-        output_set_underscanning_xrandr (manager_xrandr,
-                                         output_info->output,
-                                         output_info->is_underscanning);
+      output_set_underscanning_xrandr (manager_xrandr,
+                                       output_info->output,
+                                       output_info->is_underscanning);
 
       output->is_primary = output_info->is_primary;
       output->is_presentation = output_info->is_presentation;


### PR DESCRIPTION
This PR is an attempt to port our downstream-specific bits from 3.24 into 3.26, where the codebase has substantially changed since that previous release. As previously, this implements the basic support to allow enabling/disabling underscanning, which is not perfect since a few features (e.g. Reverting changes) don't work at the moment because of a combination of issues with the Intel driver, which make it fairly difficult to have those bits working reliably.

Note: it should be possible to upstream the first 4 commits, but the codebase affected has also changed significantly in master (compared to this 3.26 baseline), so we'll defer upstreaming until the next rebase.

https://phabricator.endlessm.com/T20655