### PR TITLE
backends: Don't center the pointer on initialization

### DIFF
--- a/src/backends/meta-backend.c
+++ b/src/backends/meta-backend.c
@@ -474,7 +474,18 @@ meta_backend_real_post_init (MetaBackend *backend)
 
   if (!meta_monitor_manager_is_headless (priv->monitor_manager))
     {
-      center_pointer (backend);
+      MetaMonitorManager *monitor_manager = priv->monitor_manager;
+      MetaLogicalMonitor *primary;
+
+      primary =
+        meta_monitor_manager_get_primary_logical_monitor (monitor_manager);
+
+      /* Move the pointer out of the way to avoid hovering over reactive
+       * elements (e.g. users list at login) causing undesired behaviour. */
+      meta_backend_warp_pointer (backend,
+                                 primary->rect.x + primary->rect.width * 0.9,
+                                 primary->rect.y + primary->rect.height * 0.9);
+
       priv->is_pointer_position_initialized = TRUE;
     }
 }


### PR DESCRIPTION
Centering the pointer at startup causes undesired behaviour if
it ends up hovering over reactive elements, that might react
to that positioning, causing confusion. This is the case of
the login dialog when a list of different users is shown, as
centering the pointer at startup in that case will get the
user in the center of the screen pre-selected, which is not
the expected behaviour (i.e. pre-selecting the first one).

Fix this by simply moving the pointer out of the way, close
to the bottom-right corner, during initialization.

Closes: https://gitlab.gnome.org/GNOME/gnome-shell/issues/157

https://phabricator.endlessm.com/T21426