### PR TITLE
backend: Don't center the pointers on monitor changes

### DIFF
--- a/src/backends/meta-backend.c
+++ b/src/backends/meta-backend.c
@@ -158,7 +158,7 @@ meta_backend_sync_screen_size (MetaBackend *backend)
 }
 
 static void
-center_pointer (MetaBackend *backend)
+reset_pointer_position (MetaBackend *backend)
 {
   MetaBackendPrivate *priv = meta_backend_get_instance_private (backend);
   MetaMonitorManager *monitor_manager = priv->monitor_manager;
@@ -167,9 +167,11 @@ center_pointer (MetaBackend *backend)
   primary =
     meta_monitor_manager_get_primary_logical_monitor (monitor_manager);
 
+  /* Move the pointer out of the way to avoid hovering over reactive
+   * elements (e.g. users list at login) causing undesired behaviour. */
   meta_backend_warp_pointer (backend,
-                             primary->rect.x + primary->rect.width / 2,
-                             primary->rect.y + primary->rect.height / 2);
+                             primary->rect.x + primary->rect.width * 0.9,
+                             primary->rect.y + primary->rect.height * 0.9);
 }
 
 void
@@ -192,7 +194,7 @@ meta_backend_monitors_changed (MetaBackend *backend)
            !priv->is_pointer_position_initialized) &&
           !meta_monitor_manager_is_headless (monitor_manager))
         {
-          center_pointer (backend);
+          reset_pointer_position (backend);
           priv->is_pointer_position_initialized = TRUE;
         }
     }
@@ -474,18 +476,7 @@ meta_backend_real_post_init (MetaBackend *backend)
 
   if (!meta_monitor_manager_is_headless (priv->monitor_manager))
     {
-      MetaMonitorManager *monitor_manager = priv->monitor_manager;
-      MetaLogicalMonitor *primary;
-
-      primary =
-        meta_monitor_manager_get_primary_logical_monitor (monitor_manager);
-
-      /* Move the pointer out of the way to avoid hovering over reactive
-       * elements (e.g. users list at login) causing undesired behaviour. */
-      meta_backend_warp_pointer (backend,
-                                 primary->rect.x + primary->rect.width * 0.9,
-                                 primary->rect.y + primary->rect.height * 0.9);
-
+      reset_pointer_position (backend);
       priv->is_pointer_position_initialized = TRUE;
     }
 }


### PR DESCRIPTION
As a follow up to the patch from a95cbd0a, we need to make sure
that the pointer is out of the way as well when monitors changed,
since that's the event that will prevail in some cases. Besides,
this is also consistent with what the code before a95cbd0a was,
which initialized the pointer position in the same way both in
this case and in the real_post_init() function.

Closes: https://gitlab.gnome.org/GNOME/gnome-shell/issues/157