### PR TITLE
meta-monitor-manager: use MonitorsConfig to track switch_config

### DIFF
--- a/src/backends/meta-monitor-config-manager.c
+++ b/src/backends/meta-monitor-config-manager.c
@@ -1019,6 +1019,7 @@ meta_monitor_config_manager_create_for_switch_config (MetaMonitorConfigManager  
                                                       MetaMonitorSwitchConfigType  config_type)
 {
   MetaMonitorManager *monitor_manager = config_manager->monitor_manager;
+  MetaMonitorsConfig *config;
 
   if (!meta_monitor_manager_can_switch_config (monitor_manager))
     return NULL;
@@ -1026,18 +1027,27 @@ meta_monitor_config_manager_create_for_switch_config (MetaMonitorConfigManager  
   switch (config_type)
     {
     case META_MONITOR_SWITCH_CONFIG_ALL_MIRROR:
-      return create_for_switch_config_all_mirror (config_manager);
-    case META_MONITOR_SWITCH_CONFIG_ALL_LINEAR:
-      return meta_monitor_config_manager_create_linear (config_manager);
-    case META_MONITOR_SWITCH_CONFIG_EXTERNAL:
-      return create_for_switch_config_external (config_manager);
-    case META_MONITOR_SWITCH_CONFIG_BUILTIN:
-      return create_for_switch_config_builtin (config_manager);
-    case META_MONITOR_SWITCH_CONFIG_UNKNOWN:
-      g_warn_if_reached ();
+      config = create_for_switch_config_all_mirror (config_manager);
       break;
+    case META_MONITOR_SWITCH_CONFIG_ALL_LINEAR:
+      config = meta_monitor_config_manager_create_linear (config_manager);
+      break;
+    case META_MONITOR_SWITCH_CONFIG_EXTERNAL:
+      config = create_for_switch_config_external (config_manager);
+      break;
+    case META_MONITOR_SWITCH_CONFIG_BUILTIN:
+      config = create_for_switch_config_builtin (config_manager);
+      break;
+    case META_MONITOR_SWITCH_CONFIG_UNKNOWN:
+    default:
+      g_warn_if_reached ();
+      return NULL;
     }
-  return NULL;
+
+  if (config)
+    meta_monitors_config_set_switch_config (config, config_type);
+
+  return config;
 }
 
 void
@@ -1229,6 +1239,19 @@ meta_monitors_config_key_equal (gconstpointer data_a,
   return TRUE;
 }
 
+MetaMonitorSwitchConfigType
+meta_monitors_config_get_switch_config (MetaMonitorsConfig *config)
+{
+  return config->switch_config;
+}
+
+void
+meta_monitors_config_set_switch_config (MetaMonitorsConfig          *config,
+                                        MetaMonitorSwitchConfigType  switch_config)
+{
+  config->switch_config = switch_config;
+}
+
 MetaMonitorsConfig *
 meta_monitors_config_new_full (GList                        *logical_monitor_configs,
                                GList                        *disabled_monitor_specs,
@@ -1244,6 +1267,7 @@ meta_monitors_config_new_full (GList                        *logical_monitor_con
                                               disabled_monitor_specs);
   config->layout_mode = layout_mode;
   config->flags = flags;
+  config->switch_config = META_MONITOR_SWITCH_CONFIG_UNKNOWN;
 
   return config;
 }

--- a/src/backends/meta-monitor-config-manager.h
+++ b/src/backends/meta-monitor-config-manager.h
@@ -69,6 +69,8 @@ struct _MetaMonitorsConfig
   MetaMonitorsConfigFlag flags;
 
   MetaLogicalMonitorLayoutMode layout_mode;
+
+  MetaMonitorSwitchConfigType switch_config;
 };
 
 #define META_TYPE_MONITORS_CONFIG (meta_monitors_config_get_type ())
@@ -123,6 +125,11 @@ MetaMonitorsConfig * meta_monitors_config_new (MetaMonitorManager           *mon
                                                GList                        *logical_monitor_configs,
                                                MetaLogicalMonitorLayoutMode  layout_mode,
                                                MetaMonitorsConfigFlag        flags);
+
+MetaMonitorSwitchConfigType meta_monitors_config_get_switch_config (MetaMonitorsConfig *config);
+
+void meta_monitors_config_set_switch_config (MetaMonitorsConfig          *config,
+                                             MetaMonitorSwitchConfigType  switch_config);
 
 unsigned int meta_monitors_config_key_hash (gconstpointer config_key);
 


### PR DESCRIPTION
When constructing MetaMonitorsConfig objects, store which type
of switch_config they are for (or UNKNOWN if it is not such
type of config).

Stop unconditionally setting current_switch_config to UNKNOWN when
handling monitors changed events. Instead, set it to the switch_config
type stored in the MonitorsConfig in the codepath that updates logical
state. In addition to being called in the hotplug case along the same
code flow that generates monitors changed events, this is also called
in the coldplug case where a secondary monitor was connected before
mutter was started.

When creating the default linear display config, create it as a
switch_config so that internal state gets updated to represent
linear mode when this config is used.

The previous behaviour of unconditionally resetting current_switch_config
to UNKNOWN was breaking the internal state machine for display config
switching, causing misbehaviour in gnome-shell's switchMonitor UI when
using display switch hotkeys. The lack of internal tracking when the
displays are already in the default "Join Displays" linear mode was
then causing the first display switch hotkey press to do nothing
(it would attempt to select "Join Displays" mode, but that was already
active).

https://gitlab.gnome.org/GNOME/mutter/issues/281
https://gitlab.gnome.org/GNOME/mutter/merge_requests/213
https://phabricator.endlessm.com/T21405