### PR TITLE
MonitorManager: don't use GBytes data after freeing it

### DIFF
--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -2607,7 +2607,7 @@ static GVariant *
 meta_monitor_manager_get_output_auxiliary_payload (MetaMonitorManager *manager,
                                                    MetaOutput         *output)
 {
-  GBytes *edid;
+  g_autoptr(GBytes) edid = NULL;
   GVariant *edid_variant;
   const guint8 *raw_edid = NULL;
   gsize edid_length = 0;
@@ -2615,10 +2615,7 @@ meta_monitor_manager_get_output_auxiliary_payload (MetaMonitorManager *manager,
 
   edid = manager_class->read_edid (manager, output);
   if (edid != NULL)
-    {
-      raw_edid = g_bytes_get_data (edid, &edid_length);
-      g_bytes_unref (edid);
-    }
+    raw_edid = g_bytes_get_data (edid, &edid_length);
 
   edid_variant =
     g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,


### PR DESCRIPTION
There's no guarantee that anybody else holds a reference to the GBytes
returned from read_edid(), and in practice nobody does. As a result,
raw_edid refers to freed memory.

This should be squashed into 'Record monitor connect/disconnect events.'
in a future rebase.

Found while Valgrinding on https://phabricator.endlessm.com/T23973.