### PR TITLE
backends/x11: Force-update cursor when theme or size changed

### DIFF
--- a/src/backends/x11/meta-backend-x11.c
+++ b/src/backends/x11/meta-backend-x11.c
@@ -723,3 +723,13 @@ meta_backend_x11_get_xwindow (MetaBackendX11 *x11)
   ClutterActor *stage = meta_backend_get_stage (META_BACKEND (x11));
   return clutter_x11_get_stage_window (CLUTTER_STAGE (stage));
 }
+
+void
+meta_backend_x11_reload_cursor (MetaBackendX11 *x11)
+{
+  MetaBackend *backend = META_BACKEND (x11);
+  MetaCursorRenderer *cursor_renderer =
+    meta_backend_get_cursor_renderer (backend);
+
+  meta_cursor_renderer_force_update (cursor_renderer);
+}

--- a/src/backends/x11/meta-backend-x11.h
+++ b/src/backends/x11/meta-backend-x11.h
@@ -57,4 +57,6 @@ void meta_backend_x11_handle_event (MetaBackendX11 *x11,
 
 uint8_t meta_backend_x11_get_xkb_event_base (MetaBackendX11 *x11);
 
+void meta_backend_x11_reload_cursor (MetaBackendX11 *x11);
+
 #endif /* META_BACKEND_X11_H */

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2155,6 +2155,7 @@ update_cursor_theme (void)
       {
         Display *xdisplay = meta_backend_x11_get_xdisplay (META_BACKEND_X11 (backend));
         set_cursor_theme (xdisplay);
+        meta_backend_x11_reload_cursor (META_BACKEND_X11 (backend));
       }
   }
 }


### PR DESCRIPTION
Force update the cursor renderer after theme or size changes; otherwise
we'll be stuck with the old theme and/or size until something else
triggers resetting of the cursor.

https://phabricator.endlessm.com/T24342