### PR TITLE
compositor: add a new plugin function when unmanaged

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -580,6 +580,8 @@ meta_compositor_unmanage (MetaCompositor *compositor)
        * window manager won't be able to redirect subwindows */
       XCompositeUnredirectSubwindows (xdisplay, xroot, CompositeRedirectManual);
     }
+
+  meta_plugin_manager_stop (compositor->plugin_mgr);
 }
 
 /**

--- a/src/compositor/meta-plugin-manager.c
+++ b/src/compositor/meta-plugin-manager.c
@@ -118,6 +118,16 @@ meta_plugin_manager_new (MetaCompositor *compositor)
   return plugin_mgr;
 }
 
+void
+meta_plugin_manager_stop (MetaPluginManager *plugin_mgr)
+{
+  MetaPlugin *plugin = plugin_mgr->plugin;
+  MetaPluginClass *klass = META_PLUGIN_GET_CLASS (plugin);
+
+  if (klass->stop)
+    klass->stop (plugin);
+}
+
 static void
 meta_plugin_manager_kill_window_effects (MetaPluginManager *plugin_mgr,
                                          MetaWindowActor   *actor)

--- a/src/compositor/meta-plugin-manager.h
+++ b/src/compositor/meta-plugin-manager.h
@@ -98,4 +98,6 @@ MetaInhibitShortcutsDialog *
   meta_plugin_manager_create_inhibit_shortcuts_dialog (MetaPluginManager *plugin_mgr,
                                                        MetaWindow        *window);
 
+void meta_plugin_manager_stop (MetaPluginManager *plugin_mgr);
+
 #endif

--- a/src/meta/meta-plugin.h
+++ b/src/meta/meta-plugin.h
@@ -56,6 +56,7 @@ struct _MetaPlugin
 /**
  * MetaPluginClass:
  * @start: virtual function called when the compositor starts managing a screen
+ * @stop: virtual function called when the compositor stops managing a screen
  * @minimize: virtual function called when a window is minimized
  * @size_change: virtual function called when a window changes size to/from constraints
  * @map: virtual function called when a window is mapped
@@ -85,6 +86,13 @@ struct _MetaPluginClass
    * Virtual function called when the compositor starts managing a screen
    */
   void (*start)            (MetaPlugin         *plugin);
+
+  /**
+   * MetaPluginClass::stop:
+   *
+   * Virtual function called when the compositor stops managing a screen
+   */
+  void (*stop)             (MetaPlugin         *plugin);
 
   /**
    * MetaPluginClass::minimize:


### PR DESCRIPTION
Currently the compositor plugin has no good way of knowing when it's
being unmanaged.

That would not be a problem normally, since compositors usually run
for the whole session, but there are a few caveats:
- gnome-shell (at least under X11) is automatically restarted by
  gnome-session if it crashes
- mutter and gnome-shell support being replaced with another instance,
  which is very often used in development

Combined with the fact that the compositor will emit a "destroyed"
signal for every window actor just before quitting in those scenarios,
it is useful for clients to be able to distinguish the case where
windows are not really getting destroyed.

This commit adds a new virtual method to MetaPlugin that can be used
for that purpose.

https://phabricator.endlessm.com/T24406