### PR TITLE
Revert "compositor: add a new plugin function when unmanaged"

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -580,8 +580,6 @@ meta_compositor_unmanage (MetaCompositor *compositor)
        * window manager won't be able to redirect subwindows */
       XCompositeUnredirectSubwindows (xdisplay, xroot, CompositeRedirectManual);
     }
-
-  meta_plugin_manager_stop (compositor->plugin_mgr);
 }
 
 /**

--- a/src/compositor/meta-plugin-manager.c
+++ b/src/compositor/meta-plugin-manager.c
@@ -118,16 +118,6 @@ meta_plugin_manager_new (MetaCompositor *compositor)
   return plugin_mgr;
 }
 
-void
-meta_plugin_manager_stop (MetaPluginManager *plugin_mgr)
-{
-  MetaPlugin *plugin = plugin_mgr->plugin;
-  MetaPluginClass *klass = META_PLUGIN_GET_CLASS (plugin);
-
-  if (klass->stop)
-    klass->stop (plugin);
-}
-
 static void
 meta_plugin_manager_kill_window_effects (MetaPluginManager *plugin_mgr,
                                          MetaWindowActor   *actor)

--- a/src/compositor/meta-plugin-manager.h
+++ b/src/compositor/meta-plugin-manager.h
@@ -98,6 +98,4 @@ MetaInhibitShortcutsDialog *
   meta_plugin_manager_create_inhibit_shortcuts_dialog (MetaPluginManager *plugin_mgr,
                                                        MetaWindow        *window);
 
-void meta_plugin_manager_stop (MetaPluginManager *plugin_mgr);
-
 #endif

--- a/src/meta/meta-plugin.h
+++ b/src/meta/meta-plugin.h
@@ -56,7 +56,6 @@ struct _MetaPlugin
 /**
  * MetaPluginClass:
  * @start: virtual function called when the compositor starts managing a screen
- * @stop: virtual function called when the compositor stops managing a screen
  * @minimize: virtual function called when a window is minimized
  * @size_change: virtual function called when a window changes size to/from constraints
  * @map: virtual function called when a window is mapped
@@ -86,13 +85,6 @@ struct _MetaPluginClass
    * Virtual function called when the compositor starts managing a screen
    */
   void (*start)            (MetaPlugin         *plugin);
-
-  /**
-   * MetaPluginClass::stop:
-   *
-   * Virtual function called when the compositor stops managing a screen
-   */
-  void (*stop)             (MetaPlugin         *plugin);
 
   /**
    * MetaPluginClass::minimize:


### PR DESCRIPTION
This reverts commit fe63b644ffa59b963315dab379532826e45f433b, which broke the mutter ABI. Due to an ongoing distro update, gnome-shell currently cannot be built on eos master; the current binaries are built against the mutter ABI without this change. Revert it for the time being.

When gnome-shell becomes buildable again, we'll revert this again.

This backs out https://github.com/endlessm/mutter/pull/78. I will open a corresponding PR for gnome-shell; the patches there don't revert cleanly.

https://phabricator.endlessm.com/T24406