### PR TITLE
WIP: meson: Set schema dir for tests

### DIFF
--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -29,6 +29,7 @@ endif
 test_env = environment()
 test_env.set('G_TEST_SRCDIR', join_paths(top_srcdir, 'src'))
 test_env.set('G_TEST_BUILDDIR', builddir)
+test_env.set('GSETTINGS_SCHEMA_DIR', join_paths(builddir, 'data'))
 test_env.set('MUTTER_TEST_PLUGIN_PATH', '@0@'.format(default_plugin.full_path()))
 
 test_client = executable('mutter-test-client',


### PR DESCRIPTION
This is needed for running tests on build environments
that are not GitLab CI nor a default host.

https://phabricator.endlessm.com/T26224