### PR TITLE
meson: Disable tests by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -101,25 +101,25 @@ option('introspection',
 
 option('cogl_tests',
   type: 'boolean',
-  value: true,
+  value: false,
   description: 'Enable cogl tests'
 )
 
 option('clutter_tests',
   type: 'boolean',
-  value: true,
+  value: false,
   description: 'Enable clutter tests'
 )
 
 option('tests',
   type: 'boolean',
-  value: true,
+  value: false,
   description: 'Enable mutter tests'
 )
 
 option('installed_tests',
   type: 'boolean',
-  value: true,
+  value: false,
   description: 'Enable mutter installed tests'
 )
 


### PR DESCRIPTION
Jenkins is unable to test it, so disable the tests. We
can't simply pass -D*tests=false since Jenkins also runs
'ninja dist', which runs the tests anyway.

https://phabricator.endlessm.com/T26224