### PR TITLE
clutter: LEQUAL depth_testing on ClutterDeformEffect

### DIFF
--- a/clutter/clutter/clutter-deform-effect.c
+++ b/clutter/clutter/clutter-deform-effect.c
@@ -282,6 +282,7 @@ clutter_deform_effect_paint_target (ClutterOffscreenEffect *effect)
   /* enable depth testing */
   cogl_depth_state_init (&depth_state);
   cogl_depth_state_set_test_enabled (&depth_state, TRUE);
+  cogl_depth_state_set_test_function (&depth_state, COGL_DEPTH_TEST_FUNCTION_LEQUAL);
   cogl_pipeline_set_depth_state (pipeline, &depth_state, NULL);
 
   /* enable backface culling if we have a back material */


### PR DESCRIPTION
Moving an actor with a ClutterDeformEffect applied flickers because
the depth_testing is enabled if we remove it the deform effects will
work correctly.

Fixes https://gitlab.gnome.org/GNOME/mutter/issues/507