### PR TITLE
clutter: Obey default driver

### DIFF
--- a/clutter/clutter/clutter-backend.c
+++ b/clutter/clutter/clutter-backend.c
@@ -320,7 +320,7 @@ error:
   return FALSE;
 }
 
-static const struct {
+static struct {
   const char *driver_name;
   const char *driver_desc;
   CoglDriver driver_id;
@@ -329,7 +329,12 @@ static const struct {
   { "gl", "OpenGL legacy profile", COGL_DRIVER_GL },
   { "gles2", "OpenGL ES 2.0", COGL_DRIVER_GLES2 },
   { "any", "Default Cogl driver", COGL_DRIVER_ANY },
-};
+}
+#ifdef CLUTTER_DEFAULT_DRIVER
+ , temp_driver;
+#else
+ ;
+#endif
 
 static const char *allowed_drivers;
 
@@ -342,6 +347,19 @@ clutter_backend_real_create_context (ClutterBackend  *backend,
   char **known_drivers;
   gboolean allow_any;
   int i;
+
+#ifdef CLUTTER_DEFAULT_DRIVER
+  for (i = 1; i < G_N_ELEMENTS (all_known_drivers); i++)
+    {
+      if (g_str_equal (all_known_drivers[i].driver_name, CLUTTER_DEFAULT_DRIVER))
+        {
+          temp_driver = all_known_drivers[i];
+          all_known_drivers[i] = all_known_drivers[0];
+          all_known_drivers[0] = temp_driver;
+          break;
+        }
+    }
+#endif
 
   if (backend->cogl_context != NULL)
     return TRUE;

--- a/clutter/clutter/clutter-build-config.h.meson
+++ b/clutter/clutter/clutter-build-config.h.meson
@@ -12,3 +12,6 @@
 
 /* Supports PangoFt2 */
 #mesondefine HAVE_PANGO_FT2
+
+/* Default Clutter Driver */
+#mesondefine CLUTTER_DEFAULT_DRIVER

--- a/clutter/clutter/meson.build
+++ b/clutter/clutter/meson.build
@@ -396,6 +396,10 @@ cdata.set('HAVE_EVDEV', have_native_backend)
 cdata.set('HAVE_LIBWACOM', have_libwacom)
 cdata.set('HAVE_PANGO_FT2', have_pango_ft2)
 
+if default_driver != 'auto'
+  cdata.set_quoted('CLUTTER_DEFAULT_DRIVER', default_driver)
+endif
+
 clutter_build_config_h = configure_file(
   input: 'clutter-build-config.h.meson',
   output: 'clutter-build-config.h',


### PR DESCRIPTION
Until now the default driver setting would set a default for cogl that would
always be overridden by clutter based on a static order of drivers to try.

This patch moves the default driver to the top of clutter's list at runtime.