### PR TITLE
Build without full GL or GLX on ARM to fix endless mini performance

### DIFF
--- a/debian/libmutter-4-0.symbols
+++ b/debian/libmutter-4-0.symbols
@@ -2324,7 +2324,7 @@ libmutter-cogl-4.so.0 libmutter-4-0 #MINVER#
  _cogl_winsys_egl_renderer_connect_common@Base 3.29.4
  _cogl_winsys_egl_xlib_get_vtable@Base 3.29.4
  _cogl_winsys_error_quark@Base 3.29.4
- _cogl_winsys_glx_get_vtable@Base 3.29.4
+ (arch=!armhf !armel)_cogl_winsys_glx_get_vtable@Base 3.29.4
  cogl_atlas_texture_get_gtype@Base 3.29.4
  cogl_atlas_texture_new_from_bitmap@Base 3.29.4
  cogl_atlas_texture_new_from_data@Base 3.29.4
@@ -2559,7 +2559,7 @@ libmutter-cogl-4.so.0 libmutter-4-0 #MINVER#
  cogl_gles2_texture_get_handle@Base 3.29.4
  cogl_glib_renderer_source_new@Base 3.29.4
  cogl_glib_source_new@Base 3.29.4
- cogl_glx_context_get_glx_context@Base 3.29.4
+ (arch=!armhf !armel)cogl_glx_context_get_glx_context@Base 3.29.4
  cogl_gtype_matrix_get_type@Base 3.29.4
  cogl_handle_get_type@Base 3.29.4
  cogl_handle_ref@Base 3.29.4

--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,7 @@ endif
 
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH),armel armhf))
 CONFFLAGS += \
-	-Ddefault_driver=gles2
+	-Dopengl=false -Dglx=false
 else
 CONFFLAGS += \
 	-Ddefault_driver=gl


### PR DESCRIPTION
Mutter preferentially uses glx + gl3 when available, which ends up
using mesa's software rendering path on the endless mini.

Disabling full GL and GLX forces us into the EGL + GLESv2 path we
need to use our Mali drivers.

Fixes https://phabricator.endlessm.com/T26795