### PR TITLE
Skip startup notifications for apps blacklisted by parental controls

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,7 @@ ice_dep = dependency('ice')
 atk_dep = dependency('atk', version: atk_req)
 libcanberra_dep = dependency('libcanberra', version: libcanberra_req)
 eosmetrics_dep = dependency('eosmetrics-0')
+malcontent_dep = dependency('malcontent-0')
 
 # For now always require X11 support
 have_x11 = true

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ mutter_pkg_private_deps = [
   gnome_settings_daemon_dep,
   json_glib_dep,
   libcanberra_dep,
+  malcontent_dep,
   xkbcommon_dep,
 ]
 


### PR DESCRIPTION
Note that this does not skip notifications started from
`gtk_shell_notify_launch` (wayland only) as that method does not contain
enough information to build an app info needed to check the parental
controls settings.

Signed-off-by: Andre Moreira Magalhaes <andre@endlessm.com>

https://phabricator.endlessm.com/T26990