### PR TITLE
Fix force quit dialog issue

### DIFF
--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -1932,8 +1932,8 @@ meta_x11_display_set_input_focus_xwindow (MetaX11Display *x11_display,
   if (meta_display_timestamp_too_old (x11_display->display, &timestamp))
     return;
 
-  serial = XNextRequest (x11_display->xdisplay);
   meta_x11_display_set_input_focus_internal (x11_display, window, timestamp);
+  serial = XNextRequest (x11_display->xdisplay);
   meta_x11_display_update_focus_window (x11_display, window, serial, TRUE);
   meta_display_update_focus_window (x11_display->display, NULL);
   meta_display_remove_autoraise_callback (x11_display->display);

--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -1929,10 +1929,10 @@ meta_x11_display_set_input_focus_xwindow (MetaX11Display *x11_display,
 {
   gulong serial;
 
-  meta_display_unset_input_focus (x11_display->display, timestamp);
   serial = XNextRequest (x11_display->xdisplay);
   meta_x11_display_set_input_focus_internal (x11_display, window, timestamp);
   meta_x11_display_update_focus_window (x11_display, window, serial, TRUE);
+  meta_display_unset_input_focus (x11_display->display, timestamp);
 }
 
 static MetaX11DisplayLogicalMonitorData *

--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -1929,10 +1929,15 @@ meta_x11_display_set_input_focus_xwindow (MetaX11Display *x11_display,
 {
   gulong serial;
 
+  if (meta_display_timestamp_too_old (x11_display->display, &timestamp))
+    return;
+
   serial = XNextRequest (x11_display->xdisplay);
   meta_x11_display_set_input_focus_internal (x11_display, window, timestamp);
   meta_x11_display_update_focus_window (x11_display, window, serial, TRUE);
-  meta_display_unset_input_focus (x11_display->display, timestamp);
+  meta_display_update_focus_window (x11_display->display, NULL);
+  meta_display_remove_autoraise_callback (x11_display->display);
+  x11_display->display->last_focus_time = timestamp;
 }
 
 static MetaX11DisplayLogicalMonitorData *


### PR DESCRIPTION
This cherry-picks the commits from https://gitlab.gnome.org/GNOME/mutter/merge_requests/909/commits which fixes an infinite loop issue when setting the keyboard focus on GNOME Shell `CloseDialog::vfunc_focus` which calls `this._dialog.grab_key_focus()` which ends up invoking `vfunc_focus` again.

It also includes 1 extra patch (also from upstream but not in the upstream MR above) that was an ancestor (to avoid conflicts when applying the changes above).

https://phabricator.endlessm.com/T28185