### PR TITLE
Performance cherry-picks for Raspberry Pi 4

### DIFF
--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -1771,6 +1771,15 @@ clutter_actor_unmap (ClutterActor *self)
 }
 
 static void
+clutter_actor_queue_shallow_relayout (ClutterActor *self)
+{
+  ClutterActor *stage = _clutter_actor_get_stage_internal (self);
+
+  if (stage != NULL)
+    clutter_stage_queue_actor_relayout (CLUTTER_STAGE (stage), self);
+}
+
+static void
 clutter_actor_real_show (ClutterActor *self)
 {
   ClutterActorPrivate *priv = self->priv;
@@ -1802,6 +1811,11 @@ clutter_actor_real_show (ClutterActor *self)
       priv->needs_allocation     = FALSE;
 
       clutter_actor_queue_relayout (self);
+    }
+  else  /* but still don't leave the actor un-allocated before showing it */
+    {
+      clutter_actor_queue_shallow_relayout (self);
+      clutter_actor_queue_redraw (self);
     }
 }
 
@@ -2879,9 +2893,23 @@ clutter_actor_real_queue_relayout (ClutterActor *self)
   memset (priv->height_requests, 0,
           N_CACHED_SIZE_REQUESTS * sizeof (SizeRequest));
 
-  /* We need to go all the way up the hierarchy */
+  /* We may need to go all the way up the hierarchy */
   if (priv->parent != NULL)
-    _clutter_actor_queue_only_relayout (priv->parent);
+    {
+      if (priv->parent->flags & CLUTTER_ACTOR_NO_LAYOUT)
+        {
+          clutter_actor_queue_shallow_relayout (self);
+
+          /* The above might have invalidated the parent's paint volume if self
+           * has moved or resized. DnD seems to require this...
+           */
+          priv->parent->priv->needs_paint_volume_update = TRUE;
+        }
+      else
+        {
+          _clutter_actor_queue_only_relayout (priv->parent);
+        }
+    }
 }
 
 /**

--- a/clutter/clutter/clutter-stage-private.h
+++ b/clutter/clutter/clutter-stage-private.h
@@ -143,6 +143,9 @@ void            _clutter_stage_presented                (ClutterStage      *stag
 
 GList *         _clutter_stage_peek_stage_views         (ClutterStage *stage);
 
+void            clutter_stage_queue_actor_relayout      (ClutterStage *stage,
+                                                         ClutterActor *actor);
+
 G_END_DECLS
 
 #endif /* __CLUTTER_STAGE_PRIVATE_H__ */

--- a/clutter/clutter/clutter-stage-view-private.h
+++ b/clutter/clutter/clutter-stage-view-private.h
@@ -20,8 +20,8 @@
 
 #include "clutter/clutter-stage-view.h"
 
-void clutter_stage_view_blit_offscreen (ClutterStageView            *view,
-                                        const cairo_rectangle_int_t *clip);
+void clutter_stage_view_after_paint (ClutterStageView            *view,
+                                     const cairo_rectangle_int_t *clip);
 
 gboolean clutter_stage_view_is_dirty_viewport (ClutterStageView *view);
 

--- a/clutter/clutter/clutter-stage-view.c
+++ b/clutter/clutter/clutter-stage-view.c
@@ -30,6 +30,7 @@ enum
   PROP_LAYOUT,
   PROP_FRAMEBUFFER,
   PROP_OFFSCREEN,
+  PROP_SHADOWFB,
   PROP_SCALE,
 
   PROP_LAST
@@ -44,7 +45,10 @@ typedef struct _ClutterStageViewPrivate
   CoglFramebuffer *framebuffer;
 
   CoglOffscreen *offscreen;
-  CoglPipeline *pipeline;
+  CoglPipeline *offscreen_pipeline;
+
+  CoglOffscreen *shadowfb;
+  CoglPipeline *shadowfb_pipeline;
 
   guint dirty_viewport   : 1;
   guint dirty_projection : 1;
@@ -78,6 +82,8 @@ clutter_stage_view_get_framebuffer (ClutterStageView *view)
 
   if (priv->offscreen)
     return priv->offscreen;
+  else if (priv->shadowfb)
+    return priv->shadowfb;
   else
     return priv->framebuffer;
 }
@@ -99,6 +105,24 @@ clutter_stage_view_get_onscreen (ClutterStageView *view)
   return priv->framebuffer;
 }
 
+static CoglPipeline *
+clutter_stage_view_create_framebuffer_pipeline (CoglFramebuffer *framebuffer)
+{
+  CoglPipeline *pipeline;
+
+  pipeline = cogl_pipeline_new (cogl_framebuffer_get_context (framebuffer));
+
+  cogl_pipeline_set_layer_filters (pipeline, 0,
+                                   COGL_PIPELINE_FILTER_NEAREST,
+                                   COGL_PIPELINE_FILTER_NEAREST);
+  cogl_pipeline_set_layer_texture (pipeline, 0,
+                                   cogl_offscreen_get_texture (framebuffer));
+  cogl_pipeline_set_layer_wrap_mode (pipeline, 0,
+                                     COGL_PIPELINE_WRAP_MODE_CLAMP_TO_EDGE);
+
+  return pipeline;
+}
+
 static void
 clutter_stage_view_ensure_offscreen_blit_pipeline (ClutterStageView *view)
 {
@@ -109,21 +133,27 @@ clutter_stage_view_ensure_offscreen_blit_pipeline (ClutterStageView *view)
 
   g_assert (priv->offscreen != NULL);
 
-  if (priv->pipeline)
+  if (priv->offscreen_pipeline)
     return;
 
-  priv->pipeline =
-    cogl_pipeline_new (cogl_framebuffer_get_context (priv->offscreen));
-  cogl_pipeline_set_layer_filters (priv->pipeline, 0,
-                                   COGL_PIPELINE_FILTER_NEAREST,
-                                   COGL_PIPELINE_FILTER_NEAREST);
-  cogl_pipeline_set_layer_texture (priv->pipeline, 0,
-                                   cogl_offscreen_get_texture (priv->offscreen));
-  cogl_pipeline_set_layer_wrap_mode (priv->pipeline, 0,
-                                     COGL_PIPELINE_WRAP_MODE_CLAMP_TO_EDGE);
+  priv->offscreen_pipeline =
+    clutter_stage_view_create_framebuffer_pipeline (priv->offscreen);
 
   if (view_class->setup_offscreen_blit_pipeline)
-    view_class->setup_offscreen_blit_pipeline (view, priv->pipeline);
+    view_class->setup_offscreen_blit_pipeline (view, priv->offscreen_pipeline);
+}
+
+static void
+clutter_stage_view_ensure_shadowfb_blit_pipeline (ClutterStageView *view)
+{
+  ClutterStageViewPrivate *priv =
+    clutter_stage_view_get_instance_private (view);
+
+  if (priv->shadowfb_pipeline)
+    return;
+
+  priv->shadowfb_pipeline =
+    clutter_stage_view_create_framebuffer_pipeline (priv->shadowfb);
 }
 
 void
@@ -132,48 +162,93 @@ clutter_stage_view_invalidate_offscreen_blit_pipeline (ClutterStageView *view)
   ClutterStageViewPrivate *priv =
     clutter_stage_view_get_instance_private (view);
 
-  g_clear_pointer (&priv->pipeline, cogl_object_unref);
+  g_clear_pointer (&priv->offscreen_pipeline, cogl_object_unref);
 }
 
-void
-clutter_stage_view_blit_offscreen (ClutterStageView            *view,
-                                   const cairo_rectangle_int_t *rect)
+static void
+clutter_stage_view_copy_to_framebuffer (ClutterStageView            *view,
+                                        const cairo_rectangle_int_t *rect,
+                                        CoglPipeline                *pipeline,
+                                        CoglFramebuffer             *src_framebuffer,
+                                        CoglFramebuffer             *dst_framebuffer,
+                                        gboolean                     can_blit)
 {
-  ClutterStageViewPrivate *priv =
-    clutter_stage_view_get_instance_private (view);
   CoglMatrix matrix;
 
-  clutter_stage_view_get_offscreen_transformation_matrix (view, &matrix);
-  if (cogl_matrix_is_identity (&matrix))
+  /* First, try with blit */
+  if (can_blit)
     {
-      int fb_width = cogl_framebuffer_get_width (priv->framebuffer);
-      int fb_height = cogl_framebuffer_get_height (priv->framebuffer);
-
-      if (cogl_blit_framebuffer (priv->offscreen,
-                                 priv->framebuffer,
+      if (cogl_blit_framebuffer (src_framebuffer,
+                                 dst_framebuffer,
                                  0, 0,
                                  0, 0,
-                                 fb_width, fb_height,
+                                 cogl_framebuffer_get_width (dst_framebuffer),
+                                 cogl_framebuffer_get_height (dst_framebuffer),
                                  NULL))
         return;
     }
 
-  clutter_stage_view_ensure_offscreen_blit_pipeline (view);
-  cogl_framebuffer_push_matrix (priv->framebuffer);
+  /* If blit fails, fallback to the slower painting method */
+  cogl_framebuffer_push_matrix (dst_framebuffer);
 
-  /* Set transform so 0,0 is on the top left corner and 1,1 on
-   * the bottom right corner.
-   */
   cogl_matrix_init_identity (&matrix);
   cogl_matrix_translate (&matrix, -1, 1, 0);
   cogl_matrix_scale (&matrix, 2, -2, 0);
-  cogl_framebuffer_set_projection_matrix (priv->framebuffer, &matrix);
+  cogl_framebuffer_set_projection_matrix (dst_framebuffer, &matrix);
 
-  cogl_framebuffer_draw_rectangle (priv->framebuffer,
-                                   priv->pipeline,
+  cogl_framebuffer_draw_rectangle (dst_framebuffer,
+                                   pipeline,
                                    0, 0, 1, 1);
 
-  cogl_framebuffer_pop_matrix (priv->framebuffer);
+  cogl_framebuffer_pop_matrix (dst_framebuffer);
+}
+
+void
+clutter_stage_view_after_paint (ClutterStageView            *view,
+                                const cairo_rectangle_int_t *rect)
+{
+  ClutterStageViewPrivate *priv =
+    clutter_stage_view_get_instance_private (view);
+
+  if (priv->offscreen)
+    {
+      gboolean can_blit;
+      CoglMatrix matrix;
+
+      clutter_stage_view_ensure_offscreen_blit_pipeline (view);
+      clutter_stage_view_get_offscreen_transformation_matrix (view, &matrix);
+      can_blit = cogl_matrix_is_identity (&matrix);
+
+      if (priv->shadowfb)
+        {
+          clutter_stage_view_copy_to_framebuffer (view,
+                                                  rect,
+                                                  priv->offscreen_pipeline,
+                                                  priv->offscreen,
+                                                  priv->shadowfb,
+                                                  can_blit);
+        }
+      else
+        {
+          clutter_stage_view_copy_to_framebuffer (view,
+                                                  rect,
+                                                  priv->offscreen_pipeline,
+                                                  priv->offscreen,
+                                                  priv->framebuffer,
+                                                  can_blit);
+        }
+    }
+
+  if (priv->shadowfb)
+    {
+      clutter_stage_view_ensure_shadowfb_blit_pipeline (view);
+      clutter_stage_view_copy_to_framebuffer (view,
+                                              rect,
+                                              priv->shadowfb_pipeline,
+                                              priv->shadowfb,
+                                              priv->framebuffer,
+                                              TRUE);
+    }
 }
 
 float
@@ -273,6 +348,9 @@ clutter_stage_view_get_property (GObject    *object,
     case PROP_OFFSCREEN:
       g_value_set_boxed (value, priv->offscreen);
       break;
+    case PROP_SHADOWFB:
+      g_value_set_boxed (value, priv->shadowfb);
+      break;
     case PROP_SCALE:
       g_value_set_float (value, priv->scale);
       break;
@@ -318,6 +396,9 @@ clutter_stage_view_set_property (GObject      *object,
     case PROP_OFFSCREEN:
       priv->offscreen = g_value_dup_boxed (value);
       break;
+    case PROP_SHADOWFB:
+      priv->shadowfb = g_value_dup_boxed (value);
+      break;
     case PROP_SCALE:
       priv->scale = g_value_get_float (value);
       break;
@@ -334,8 +415,10 @@ clutter_stage_view_dispose (GObject *object)
     clutter_stage_view_get_instance_private (view);
 
   g_clear_pointer (&priv->framebuffer, cogl_object_unref);
+  g_clear_pointer (&priv->shadowfb, cogl_object_unref);
   g_clear_pointer (&priv->offscreen, cogl_object_unref);
-  g_clear_pointer (&priv->pipeline, cogl_object_unref);
+  g_clear_pointer (&priv->offscreen_pipeline, cogl_object_unref);
+  g_clear_pointer (&priv->shadowfb_pipeline, cogl_object_unref);
 
   G_OBJECT_CLASS (clutter_stage_view_parent_class)->dispose (object);
 }
@@ -385,6 +468,15 @@ clutter_stage_view_class_init (ClutterStageViewClass *klass)
     g_param_spec_boxed ("offscreen",
                         "Offscreen buffer",
                         "Framebuffer used as intermediate buffer",
+                        COGL_TYPE_HANDLE,
+                        G_PARAM_READWRITE |
+                        G_PARAM_CONSTRUCT_ONLY |
+                        G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_SHADOWFB] =
+    g_param_spec_boxed ("shadowfb",
+                        "Shadow framebuffer",
+                        "Framebuffer used as intermediate shadow buffer",
                         COGL_TYPE_HANDLE,
                         G_PARAM_READWRITE |
                         G_PARAM_CONSTRUCT_ONLY |

--- a/clutter/clutter/clutter-stage-window.c
+++ b/clutter/clutter/clutter-stage-window.c
@@ -249,23 +249,6 @@ _clutter_stage_window_get_redraw_clip (ClutterStageWindow *window)
   return NULL;
 }
 
-gboolean
-_clutter_stage_window_get_redraw_clip_bounds (ClutterStageWindow    *window,
-                                              cairo_rectangle_int_t *stage_clip)
-{
-  cairo_region_t *redraw_clip;
-
-  g_return_val_if_fail (CLUTTER_IS_STAGE_WINDOW (window), FALSE);
-
-  redraw_clip = _clutter_stage_window_get_redraw_clip (window);
-  if (!redraw_clip)
-    return FALSE;
-
-  cairo_region_get_extents (redraw_clip, stage_clip);
-  cairo_region_destroy (redraw_clip);
-  return TRUE;
-}
-
 void
 _clutter_stage_window_set_accept_focus (ClutterStageWindow *window,
                                         gboolean            accept_focus)

--- a/clutter/clutter/clutter-stage-window.c
+++ b/clutter/clutter/clutter-stage-window.c
@@ -235,19 +235,35 @@ _clutter_stage_window_ignoring_redraw_clips (ClutterStageWindow *window)
   return TRUE;
 }
 
-gboolean
-_clutter_stage_window_get_redraw_clip_bounds (ClutterStageWindow    *window,
-                                              cairo_rectangle_int_t *stage_clip)
+cairo_region_t *
+_clutter_stage_window_get_redraw_clip (ClutterStageWindow *window)
 {
   ClutterStageWindowInterface *iface;
 
   g_return_val_if_fail (CLUTTER_IS_STAGE_WINDOW (window), FALSE);
 
   iface = CLUTTER_STAGE_WINDOW_GET_IFACE (window);
-  if (iface->get_redraw_clip_bounds != NULL)
-    return iface->get_redraw_clip_bounds (window, stage_clip);
+  if (iface->get_redraw_clip != NULL)
+    return iface->get_redraw_clip (window);
 
-  return FALSE;
+  return NULL;
+}
+
+gboolean
+_clutter_stage_window_get_redraw_clip_bounds (ClutterStageWindow    *window,
+                                              cairo_rectangle_int_t *stage_clip)
+{
+  cairo_region_t *redraw_clip;
+
+  g_return_val_if_fail (CLUTTER_IS_STAGE_WINDOW (window), FALSE);
+
+  redraw_clip = _clutter_stage_window_get_redraw_clip (window);
+  if (!redraw_clip)
+    return FALSE;
+
+  cairo_region_get_extents (redraw_clip, stage_clip);
+  cairo_region_destroy (redraw_clip);
+  return TRUE;
 }
 
 void

--- a/clutter/clutter/clutter-stage-window.h
+++ b/clutter/clutter/clutter-stage-window.h
@@ -98,8 +98,6 @@ void              _clutter_stage_window_add_redraw_clip         (ClutterStageWin
                                                                  cairo_rectangle_int_t *stage_clip);
 gboolean          _clutter_stage_window_has_redraw_clips        (ClutterStageWindow    *window);
 gboolean          _clutter_stage_window_ignoring_redraw_clips   (ClutterStageWindow    *window);
-gboolean          _clutter_stage_window_get_redraw_clip_bounds  (ClutterStageWindow    *window,
-                                                                 cairo_rectangle_int_t *clip);
 cairo_region_t *  _clutter_stage_window_get_redraw_clip         (ClutterStageWindow    *window);
 
 void              _clutter_stage_window_set_accept_focus        (ClutterStageWindow *window,

--- a/clutter/clutter/clutter-stage-window.h
+++ b/clutter/clutter/clutter-stage-window.h
@@ -55,9 +55,7 @@ struct _ClutterStageWindowInterface
                                                  cairo_rectangle_int_t *stage_rectangle);
   gboolean          (* has_redraw_clips)        (ClutterStageWindow    *stage_window);
   gboolean          (* ignoring_redraw_clips)   (ClutterStageWindow    *stage_window);
-  gboolean          (* get_redraw_clip_bounds)  (ClutterStageWindow    *stage_window,
-                                                 cairo_rectangle_int_t *clip);
-
+  cairo_region_t *  (* get_redraw_clip)         (ClutterStageWindow    *stage_window);
 
   void              (* set_accept_focus)        (ClutterStageWindow *stage_window,
                                                  gboolean            accept_focus);
@@ -102,6 +100,7 @@ gboolean          _clutter_stage_window_has_redraw_clips        (ClutterStageWin
 gboolean          _clutter_stage_window_ignoring_redraw_clips   (ClutterStageWindow    *window);
 gboolean          _clutter_stage_window_get_redraw_clip_bounds  (ClutterStageWindow    *window,
                                                                  cairo_rectangle_int_t *clip);
+cairo_region_t *  _clutter_stage_window_get_redraw_clip         (ClutterStageWindow    *window);
 
 void              _clutter_stage_window_set_accept_focus        (ClutterStageWindow *window,
                                                                  gboolean            accept_focus);

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -142,6 +142,8 @@ struct _ClutterStagePrivate
 
   ClutterPlane current_clip_planes[4];
 
+  GHashTable *pending_relayouts;
+  unsigned int pending_relayouts_version;
   GList *pending_queue_redraws;
 
   CoglFramebuffer *active_framebuffer;
@@ -170,7 +172,6 @@ struct _ClutterStagePrivate
 
   int update_freeze_count;
 
-  guint relayout_pending       : 1;
   guint redraw_pending         : 1;
   guint is_cursor_visible      : 1;
   guint use_fog                : 1;
@@ -1278,7 +1279,26 @@ _clutter_stage_needs_update (ClutterStage *stage)
 
   priv = stage->priv;
 
-  return priv->relayout_pending || priv->redraw_pending;
+  return g_hash_table_size (priv->pending_relayouts) > 0 || priv->redraw_pending;
+}
+
+void
+clutter_stage_queue_actor_relayout (ClutterStage *stage,
+                                    ClutterActor *actor)
+{
+  ClutterStagePrivate *priv = stage->priv;
+
+  if (g_hash_table_contains (priv->pending_relayouts, stage))
+    return;
+
+  if (g_hash_table_size (priv->pending_relayouts) == 0)
+    _clutter_stage_schedule_update (stage);
+
+  if (actor == (ClutterActor *) stage)
+    g_hash_table_remove_all (priv->pending_relayouts);
+
+  g_hash_table_add (priv->pending_relayouts, g_object_ref (actor));
+  priv->pending_relayouts_version++;
 }
 
 void
@@ -1286,41 +1306,58 @@ _clutter_stage_maybe_relayout (ClutterActor *actor)
 {
   ClutterStage *stage = CLUTTER_STAGE (actor);
   ClutterStagePrivate *priv = stage->priv;
-  gfloat natural_width, natural_height;
-  ClutterActorBox box = { 0, };
+  GHashTableIter iter;
+  gpointer key;
+  int count = 0;
 
-  if (!priv->relayout_pending)
+  /* No work to do? Avoid the extraneous debug log messages too. */
+  if (g_hash_table_size (priv->pending_relayouts) == 0)
     return;
 
-  /* avoid reentrancy */
-  if (!CLUTTER_ACTOR_IN_RELAYOUT (stage))
+  CLUTTER_NOTE (ACTOR, ">>> Recomputing layout");
+
+  g_hash_table_iter_init (&iter, priv->pending_relayouts);
+  while (g_hash_table_iter_next (&iter, &key, NULL))
     {
-      priv->relayout_pending = FALSE;
-      priv->stage_was_relayout = TRUE;
+      g_autoptr (ClutterActor) queued_actor = key;
+      unsigned int old_version;
 
-      CLUTTER_NOTE (ACTOR, "Recomputing layout");
+      g_hash_table_iter_steal (&iter);
+      priv->pending_relayouts_version++;
 
-      CLUTTER_SET_PRIVATE_FLAGS (stage, CLUTTER_IN_RELAYOUT);
+      if (CLUTTER_ACTOR_IN_RELAYOUT (queued_actor))  /* avoid reentrancy */
+        continue;
 
-      natural_width = natural_height = 0;
-      clutter_actor_get_preferred_size (CLUTTER_ACTOR (stage),
-                                        NULL, NULL,
-                                        &natural_width, &natural_height);
+      /* An actor may have been destroyed or hidden between queuing and now */
+      if (clutter_actor_get_stage (queued_actor) != actor)
+        continue;
 
-      box.x1 = 0;
-      box.y1 = 0;
-      box.x2 = natural_width;
-      box.y2 = natural_height;
+      if (queued_actor == actor)
+        CLUTTER_NOTE (ACTOR, "    Deep relayout of stage %s",
+                      _clutter_actor_get_debug_name (queued_actor));
+      else
+        CLUTTER_NOTE (ACTOR, "    Shallow relayout of actor %s",
+                      _clutter_actor_get_debug_name (queued_actor));
 
-      CLUTTER_NOTE (ACTOR, "Allocating (0, 0 - %d, %d) for the stage",
-                    (int) natural_width,
-                    (int) natural_height);
+      CLUTTER_SET_PRIVATE_FLAGS (queued_actor, CLUTTER_IN_RELAYOUT);
 
-      clutter_actor_allocate (CLUTTER_ACTOR (stage),
-                              &box, CLUTTER_ALLOCATION_NONE);
+      old_version = priv->pending_relayouts_version;
+      clutter_actor_allocate_preferred_size (queued_actor,
+                                             CLUTTER_ALLOCATION_NONE);
 
-      CLUTTER_UNSET_PRIVATE_FLAGS (stage, CLUTTER_IN_RELAYOUT);
+      CLUTTER_UNSET_PRIVATE_FLAGS (queued_actor, CLUTTER_IN_RELAYOUT);
+
+      count++;
+
+      /* Prevent using an iterator that's been invalidated */
+      if (old_version != priv->pending_relayouts_version)
+        g_hash_table_iter_init (&iter, priv->pending_relayouts);
     }
+
+  CLUTTER_NOTE (ACTOR, "<<< Completed recomputing layout of %d subtrees", count);
+
+  if (count)
+    priv->stage_was_relayout = TRUE;
 }
 
 static void
@@ -1498,14 +1535,9 @@ static void
 clutter_stage_real_queue_relayout (ClutterActor *self)
 {
   ClutterStage *stage = CLUTTER_STAGE (self);
-  ClutterStagePrivate *priv = stage->priv;
   ClutterActorClass *parent_class;
 
-  if (!priv->relayout_pending)
-    {
-      _clutter_stage_schedule_update (stage);
-      priv->relayout_pending = TRUE;
-    }
+  clutter_stage_queue_actor_relayout (stage, self);
 
   /* chain up */
   parent_class = CLUTTER_ACTOR_CLASS (clutter_stage_parent_class);
@@ -1926,6 +1958,8 @@ clutter_stage_dispose (GObject *object)
                     (GDestroyNotify) free_queue_redraw_entry);
   priv->pending_queue_redraws = NULL;
 
+  g_clear_pointer (&priv->pending_relayouts, g_hash_table_destroy);
+
   /* this will release the reference on the stage */
   stage_manager = clutter_stage_manager_get_default ();
   _clutter_stage_manager_remove_stage (stage_manager, stage);
@@ -2337,11 +2371,11 @@ clutter_stage_init (ClutterStage *self)
   clutter_actor_set_background_color (CLUTTER_ACTOR (self),
                                       &default_stage_color);
 
-  /* FIXME - remove for 2.0 */
-  priv->fog.z_near = 1.0;
-  priv->fog.z_far  = 2.0;
-
-  priv->relayout_pending = TRUE;
+  priv->pending_relayouts = g_hash_table_new_full (NULL,
+                                                   NULL,
+                                                   g_object_unref,
+                                                   NULL);
+  clutter_stage_queue_actor_relayout (self, CLUTTER_ACTOR (self));
 
   clutter_actor_set_reactive (CLUTTER_ACTOR (self), TRUE);
   clutter_stage_set_title (self, g_get_prgname ());
@@ -3583,10 +3617,9 @@ clutter_stage_ensure_redraw (ClutterStage *stage)
 
   priv = stage->priv;
 
-  if (!priv->relayout_pending && !priv->redraw_pending)
+  if (!_clutter_stage_needs_update (stage))
     _clutter_stage_schedule_update (stage);
 
-  priv->relayout_pending = TRUE;
   priv->redraw_pending = TRUE;
 
   master_clock = _clutter_master_clock_get_default ();

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1374,11 +1374,10 @@ _clutter_stage_check_updated_pointers (ClutterStage *stage)
   ClutterDeviceManager *device_manager;
   GSList *updating = NULL;
   const GSList *devices;
-  cairo_rectangle_int_t clip;
+  cairo_region_t *clip;
   ClutterPoint point;
-  gboolean has_clip;
 
-  has_clip = _clutter_stage_window_get_redraw_clip_bounds (priv->impl, &clip);
+  clip = _clutter_stage_window_get_redraw_clip (priv->impl);
 
   device_manager = clutter_device_manager_get_default ();
   devices = clutter_device_manager_peek_devices (device_manager);
@@ -1401,9 +1400,7 @@ _clutter_stage_check_updated_pointers (ClutterStage *stage)
           if (!clutter_input_device_get_coords (dev, NULL, &point))
             continue;
 
-          if (!has_clip ||
-              (point.x >= clip.x && point.x < clip.x + clip.width &&
-               point.y >= clip.y && point.y < clip.y + clip.height))
+          if (!clip || cairo_region_contains_point (clip, point.x, point.y))
             updating = g_slist_prepend (updating, dev);
           break;
         default:

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1609,41 +1609,6 @@ clutter_stage_get_redraw_clip (ClutterStage *stage)
   return cairo_region_create_rectangle (&clip);
 }
 
-/**
- * clutter_stage_get_redraw_clip_bounds:
- * @stage: A #ClutterStage
- * @clip: (out caller-allocates): Return location for the clip bounds
- *
- * Gets the bounds of the current redraw for @stage in stage pixel
- * coordinates. E.g., if only a single actor has queued a redraw then
- * Clutter may redraw the stage with a clip so that it doesn't have to
- * paint every pixel in the stage. This function would then return the
- * bounds of that clip. An application can use this information to
- * avoid some extra work if it knows that some regions of the stage
- * aren't going to be painted. This should only be called while the
- * stage is being painted. If there is no current redraw clip then
- * this function will set @clip to the full extents of the stage.
- *
- * Since: 1.8
- */
-void
-clutter_stage_get_redraw_clip_bounds (ClutterStage          *stage,
-                                      cairo_rectangle_int_t *clip)
-{
-  ClutterStagePrivate *priv;
-
-  g_return_if_fail (CLUTTER_IS_STAGE (stage));
-  g_return_if_fail (clip != NULL);
-
-  priv = stage->priv;
-
-  if (!_clutter_stage_window_get_redraw_clip_bounds (priv->impl, clip))
-    {
-      /* Set clip to the full extents of the stage */
-      _clutter_stage_window_get_geometry (priv->impl, clip);
-    }
-}
-
 static ClutterActor *
 _clutter_stage_do_pick_on_view (ClutterStage     *stage,
                                 gint              x,

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1592,6 +1592,26 @@ _clutter_stage_has_full_redraw_queued (ClutterStage *stage)
     return FALSE;
 }
 
+cairo_region_t *
+clutter_stage_get_redraw_clip (ClutterStage *stage)
+{
+  ClutterStagePrivate *priv;
+  cairo_rectangle_int_t clip;
+  cairo_region_t *region;
+
+  g_return_val_if_fail (CLUTTER_IS_STAGE (stage), NULL);
+
+  priv = stage->priv;
+
+  region = _clutter_stage_window_get_redraw_clip (priv->impl);
+  if (region)
+    return region;
+
+  /* Set clip to the full extents of the stage */
+  _clutter_stage_window_get_geometry (priv->impl, &clip);
+  return cairo_region_create_rectangle (&clip);
+}
+
 /**
  * clutter_stage_get_redraw_clip_bounds:
  * @stage: A #ClutterStage

--- a/clutter/clutter/clutter-stage.h
+++ b/clutter/clutter/clutter-stage.h
@@ -236,6 +236,8 @@ CLUTTER_EXPORT
 void            clutter_stage_get_redraw_clip_bounds            (ClutterStage          *stage,
                                                                  cairo_rectangle_int_t *clip);
 CLUTTER_EXPORT
+cairo_region_t * clutter_stage_get_redraw_clip                  (ClutterStage          *stage);
+CLUTTER_EXPORT
 void            clutter_stage_ensure_viewport                   (ClutterStage          *stage);
 CLUTTER_EXPORT
 void            clutter_stage_ensure_redraw                     (ClutterStage          *stage);

--- a/clutter/clutter/clutter-stage.h
+++ b/clutter/clutter/clutter-stage.h
@@ -233,9 +233,6 @@ guchar *        clutter_stage_read_pixels                       (ClutterStage   
                                                                  gint                   height);
 
 CLUTTER_EXPORT
-void            clutter_stage_get_redraw_clip_bounds            (ClutterStage          *stage,
-                                                                 cairo_rectangle_int_t *clip);
-CLUTTER_EXPORT
 cairo_region_t * clutter_stage_get_redraw_clip                  (ClutterStage          *stage);
 CLUTTER_EXPORT
 void            clutter_stage_ensure_viewport                   (ClutterStage          *stage);

--- a/clutter/clutter/clutter-text.c
+++ b/clutter/clutter/clutter-text.c
@@ -5965,6 +5965,53 @@ clutter_text_get_line_wrap_mode (ClutterText *self)
   return self->priv->wrap_mode;
 }
 
+static gboolean
+attr_list_equal (PangoAttrList *old_attrs, PangoAttrList *new_attrs)
+{
+  PangoAttrIterator *i, *j;
+  gboolean equal = TRUE;
+
+  if (old_attrs == new_attrs)
+    return TRUE;
+
+  if (old_attrs == NULL || new_attrs == NULL)
+    return FALSE;
+
+  i = pango_attr_list_get_iterator (old_attrs);
+  j = pango_attr_list_get_iterator (new_attrs);
+
+  do
+    {
+      GSList *old_attributes, *new_attributes, *a, *b;
+
+      old_attributes = pango_attr_iterator_get_attrs (i);
+      new_attributes = pango_attr_iterator_get_attrs (j);
+
+      for (a = old_attributes, b = new_attributes;
+           a != NULL && b != NULL && equal;
+           a = a->next, b = b->next)
+        {
+          if (!pango_attribute_equal (a->data, b->data))
+            equal = FALSE;
+        }
+
+      if (a != NULL || b != NULL)
+        equal = FALSE;
+
+      g_slist_free (old_attributes);
+      g_slist_free (new_attributes);
+    }
+  while (equal && pango_attr_iterator_next (i) && pango_attr_iterator_next (j));
+
+  if (pango_attr_iterator_next (i) || pango_attr_iterator_next (j))
+    equal = FALSE;
+
+  pango_attr_iterator_destroy (i);
+  pango_attr_iterator_destroy (j);
+
+  return equal;
+}
+
 /**
  * clutter_text_set_attributes:
  * @self: a #ClutterText
@@ -5988,10 +6035,7 @@ clutter_text_set_attributes (ClutterText   *self,
 
   priv = self->priv;
 
-  /* While we should probably test for equality, Pango doesn't
-   * provide us an easy method to check for AttrList equality.
-   */
-  if (priv->attrs == attrs)
+  if (attr_list_equal (priv->attrs, attrs))
     return;
 
   if (attrs)

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -883,27 +883,34 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
       cairo_rectangle_int_t clip_rect;
       cairo_rectangle_int_t scissor_rect;
 
-      cairo_region_get_extents (fb_clip_region, &clip_rect);
-
-      calculate_scissor_region (&clip_rect,
-                                subpixel_compensation,
-                                fb_width, fb_height,
-                                &scissor_rect);
-
-      CLUTTER_NOTE (CLIPPING,
-                    "Stage clip pushed: x=%d, y=%d, width=%d, height=%d\n",
-                    scissor_rect.x,
-                    scissor_rect.y,
-                    scissor_rect.width,
-                    scissor_rect.height);
-
       stage_cogl->using_clipped_redraw = TRUE;
 
-      cogl_framebuffer_push_scissor_clip (fb,
-                                          scissor_rect.x,
-                                          scissor_rect.y,
-                                          scissor_rect.width,
-                                          scissor_rect.height);
+      if (cairo_region_num_rectangles (fb_clip_region) == 1)
+        {
+          cairo_region_get_extents (fb_clip_region, &clip_rect);
+
+          calculate_scissor_region (&clip_rect,
+                                    subpixel_compensation,
+                                    fb_width, fb_height,
+                                    &scissor_rect);
+
+          CLUTTER_NOTE (CLIPPING,
+                        "Stage clip pushed: x=%d, y=%d, width=%d, height=%d\n",
+                        scissor_rect.x,
+                        scissor_rect.y,
+                        scissor_rect.width,
+                        scissor_rect.height);
+
+          cogl_framebuffer_push_scissor_clip (fb,
+                                              scissor_rect.x,
+                                              scissor_rect.y,
+                                              scissor_rect.width,
+                                              scissor_rect.height);
+        }
+      else
+        {
+          cogl_framebuffer_push_region_clip (fb, fb_clip_region);
+        }
 
       paint_stage (stage_cogl, view, fb_clip_region);
 

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -56,7 +56,7 @@ typedef struct _ClutterStageViewCoglPrivate
    */
 #define DAMAGE_HISTORY_MAX 16
 #define DAMAGE_HISTORY(x) ((x) & (DAMAGE_HISTORY_MAX - 1))
-  cairo_rectangle_int_t damage_history[DAMAGE_HISTORY_MAX];
+  cairo_region_t * damage_history[DAMAGE_HISTORY_MAX];
   unsigned int damage_index;
 } ClutterStageViewCoglPrivate;
 
@@ -296,13 +296,10 @@ clutter_stage_cogl_has_redraw_clips (ClutterStageWindow *stage_window)
   /* NB: at the start of each new frame there is an implied clip that
    * clips everything (i.e. nothing would be drawn) so we need to make
    * sure we return True in the un-initialized case here.
-   *
-   * NB: a clip width of 0 means a full stage redraw has been queued
-   * so we effectively don't have any redraw clips in that case.
    */
   if (!stage_cogl->initialized_redraw_clip ||
       (stage_cogl->initialized_redraw_clip &&
-       stage_cogl->bounding_redraw_clip.width != 0))
+       stage_cogl->redraw_clip))
     return TRUE;
   else
     return FALSE;
@@ -313,9 +310,9 @@ clutter_stage_cogl_ignoring_redraw_clips (ClutterStageWindow *stage_window)
 {
   ClutterStageCogl *stage_cogl = CLUTTER_STAGE_COGL (stage_window);
 
-  /* NB: a clip width of 0 means a full stage redraw is required */
+  /* NB: a NULL clip means a full stage redraw is required */
   if (stage_cogl->initialized_redraw_clip &&
-      stage_cogl->bounding_redraw_clip.width == 0)
+      !stage_cogl->redraw_clip)
     return TRUE;
   else
     return FALSE;
@@ -346,11 +343,11 @@ clutter_stage_cogl_add_redraw_clip (ClutterStageWindow    *stage_window,
     return;
 
   /* A NULL stage clip means a full stage redraw has been queued and
-   * we keep track of this by setting a zero width
-   * stage_cogl->bounding_redraw_clip */
+   * we keep track of this by setting a NULL redraw_clip.
+   */
   if (stage_clip == NULL)
     {
-      stage_cogl->bounding_redraw_clip.width = 0;
+      g_clear_pointer (&stage_cogl->redraw_clip, cairo_region_destroy);
       stage_cogl->initialized_redraw_clip = TRUE;
       return;
     }
@@ -359,34 +356,27 @@ clutter_stage_cogl_add_redraw_clip (ClutterStageWindow    *stage_window,
   if (stage_clip->width == 0 || stage_clip->height == 0)
     return;
 
-  if (!stage_cogl->initialized_redraw_clip)
+  if (!stage_cogl->redraw_clip)
     {
-      stage_cogl->bounding_redraw_clip = *stage_clip;
+      stage_cogl->redraw_clip = cairo_region_create_rectangle (stage_clip);
     }
-  else if (stage_cogl->bounding_redraw_clip.width > 0)
+  else
     {
-      _clutter_util_rectangle_union (&stage_cogl->bounding_redraw_clip,
-                                     stage_clip,
-                                     &stage_cogl->bounding_redraw_clip);
+      cairo_region_union_rectangle (stage_cogl->redraw_clip, stage_clip);
     }
 
   stage_cogl->initialized_redraw_clip = TRUE;
 }
 
-static gboolean
-clutter_stage_cogl_get_redraw_clip_bounds (ClutterStageWindow    *stage_window,
-                                           cairo_rectangle_int_t *stage_clip)
+static cairo_region_t *
+clutter_stage_cogl_get_redraw_clip (ClutterStageWindow *stage_window)
 {
   ClutterStageCogl *stage_cogl = CLUTTER_STAGE_COGL (stage_window);
 
-  if (stage_cogl->using_clipped_redraw)
-    {
-      *stage_clip = stage_cogl->bounding_redraw_clip;
+  if (stage_cogl->using_clipped_redraw && stage_cogl->redraw_clip)
+    return cairo_region_copy (stage_cogl->redraw_clip);
 
-      return TRUE;
-    }
-
-  return FALSE;
+  return NULL;
 }
 
 static inline gboolean
@@ -433,9 +423,12 @@ paint_damage_region (ClutterStageWindow    *stage_window,
   cogl_framebuffer_draw_rectangle (framebuffer, overlay_blue, x_1, y_1, x_2, y_2);
 
   /* Red for the clip */
-  if (stage_cogl->initialized_redraw_clip)
+  if (stage_cogl->initialized_redraw_clip &&
+      stage_cogl->redraw_clip)
     {
       static CoglPipeline *overlay_red = NULL;
+      cairo_rectangle_int_t *rects;
+      int n_rects, i;
 
       if (G_UNLIKELY (overlay_red == NULL))
         {
@@ -443,12 +436,17 @@ paint_damage_region (ClutterStageWindow    *stage_window,
           cogl_pipeline_set_color4ub (overlay_red, 0x33, 0x00, 0x00, 0x33);
         }
 
-      x_1 = stage_cogl->bounding_redraw_clip.x;
-      x_2 = stage_cogl->bounding_redraw_clip.x + stage_cogl->bounding_redraw_clip.width;
-      y_1 = stage_cogl->bounding_redraw_clip.y;
-      y_2 = stage_cogl->bounding_redraw_clip.y + stage_cogl->bounding_redraw_clip.height;
+      n_rects = cairo_region_num_rectangles (stage_cogl->redraw_clip);
+      for (i = 0; i < n_rects; i++)
+        {
+          cairo_region_get_rectangle (stage_cogl->redraw_clip, i, &rects[i]);
+          x_1 = rects[i].x;
+          x_2 = rects[i].x + rects[i].width;
+          y_1 = rects[i].y;
+          y_2 = rects[i].y + rects[i].height;
 
-      cogl_framebuffer_draw_rectangle (framebuffer, overlay_red, x_1, y_1, x_2, y_2);
+          cogl_framebuffer_draw_rectangle (framebuffer, overlay_red, x_1, y_1, x_2, y_2);
+        }
     }
 
   cogl_framebuffer_pop_matrix (framebuffer);
@@ -519,42 +517,49 @@ swap_framebuffer (ClutterStageWindow    *stage_window,
 static void
 paint_stage (ClutterStageCogl            *stage_cogl,
              ClutterStageView            *view,
-             const cairo_rectangle_int_t *clip)
+             cairo_region_t              *clip)
 {
   ClutterStage *stage = stage_cogl->wrapper;
+  cairo_rectangle_int_t clip_rect;
+
+  cairo_region_get_extents (clip, &clip_rect);
 
   _clutter_stage_maybe_setup_viewport (stage, view);
-  _clutter_stage_paint_view (stage, view, clip);
+  _clutter_stage_paint_view (stage, view, &clip_rect);
 
   if (clutter_stage_view_get_onscreen (view) !=
       clutter_stage_view_get_framebuffer (view))
     {
-      clutter_stage_view_blit_offscreen (view, clip);
+      clutter_stage_view_blit_offscreen (view, &clip_rect);
     }
 }
 
 static void
-fill_current_damage_history_and_step (ClutterStageView *view)
+fill_current_damage_history (ClutterStageView *view,
+                             cairo_region_t   *damage)
 {
   ClutterStageViewCogl *view_cogl = CLUTTER_STAGE_VIEW_COGL (view);
   ClutterStageViewCoglPrivate *view_priv =
     clutter_stage_view_cogl_get_instance_private (view_cogl);
-  cairo_rectangle_int_t view_rect;
-  float fb_scale;
-  cairo_rectangle_int_t *current_fb_damage;
+  cairo_region_t **current_fb_damage;
 
   current_fb_damage =
     &view_priv->damage_history[DAMAGE_HISTORY (view_priv->damage_index)];
-  clutter_stage_view_get_layout (view, &view_rect);
-  fb_scale = clutter_stage_view_get_scale (view);
 
-  *current_fb_damage = (cairo_rectangle_int_t) {
-    .x = 0,
-    .y = 0,
-    .width = ceilf (view_rect.width * fb_scale),
-    .height = ceilf (view_rect.height * fb_scale)
-  };
+  g_clear_pointer (current_fb_damage, cairo_region_destroy);
+  *current_fb_damage = cairo_region_copy (damage);
   view_priv->damage_index++;
+}
+
+static void
+fill_current_damage_history_rectangle (ClutterStageView            *view,
+                                       const cairo_rectangle_int_t *rect)
+{
+  cairo_region_t *damage;
+
+  damage = cairo_region_create_rectangle (rect);
+  fill_current_damage_history (view, damage);
+  cairo_region_destroy (damage);
 }
 
 static void
@@ -654,9 +659,11 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
   gboolean do_swap_buffer;
   gboolean swap_with_damage;
   ClutterActor *wrapper;
-  cairo_rectangle_int_t redraw_clip;
+  cairo_region_t *redraw_clip;
+  cairo_region_t *fb_clip_region;
   cairo_rectangle_int_t swap_region;
-  cairo_rectangle_int_t fb_clip_region;
+  cairo_rectangle_int_t clip_rect;
+  cairo_rectangle_int_t redraw_rect;
   gboolean clip_region_empty;
   float fb_scale;
   int subpixel_compensation = 0;
@@ -675,20 +682,19 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
 
   has_buffer_age = cogl_is_onscreen (fb) && is_buffer_age_enabled ();
 
-  /* NB: a zero width redraw clip == full stage redraw */
-  if (stage_cogl->bounding_redraw_clip.width == 0)
+  /* NB: a NULL redraw clip == full stage redraw */
+  if (!stage_cogl->redraw_clip)
     have_clip = FALSE;
   else
     {
-      redraw_clip = stage_cogl->bounding_redraw_clip;
-      _clutter_util_rectangle_intersection (&redraw_clip,
-                                            &view_rect,
-                                            &redraw_clip);
+      cairo_region_t *view_region;
+      redraw_clip = cairo_region_copy (stage_cogl->redraw_clip);
 
-      have_clip = !(redraw_clip.x == view_rect.x &&
-                    redraw_clip.y == view_rect.y &&
-                    redraw_clip.width == view_rect.width &&
-                    redraw_clip.height == view_rect.height);
+      view_region = cairo_region_create_rectangle (&view_rect);
+      cairo_region_intersect (redraw_clip, view_region);
+
+      have_clip = !cairo_region_equal (redraw_clip, view_region);
+      cairo_region_destroy (view_region);
     }
 
   may_use_clipped_redraw = FALSE;
@@ -700,25 +706,51 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
       cogl_onscreen_get_frame_counter (COGL_ONSCREEN (fb)) > 3)
     {
       ClutterRect rect;
+      cairo_rectangle_int_t *rects;
+      int n_rects, i;
 
       may_use_clipped_redraw = TRUE;
 
-      _clutter_util_rect_from_rectangle (&redraw_clip, &rect);
-      clutter_rect_offset (&rect, -view_rect.x, -view_rect.y);
-      scale_and_clamp_rect (&rect, fb_scale, &fb_clip_region);
+      fb_clip_region = cairo_region_create ();
+
+      n_rects = cairo_region_num_rectangles (redraw_clip);
+      rects = g_new (cairo_rectangle_int_t, n_rects);
+      for (i = 0; i < n_rects; i++)
+        {
+          cairo_rectangle_int_t new_fb_clip_rect;
+
+          cairo_region_get_rectangle (redraw_clip, i, &rects[i]);
+
+          _clutter_util_rect_from_rectangle (&rects[i], &rect);
+          clutter_rect_offset (&rect, -view_rect.x, -view_rect.y);
+          scale_and_clamp_rect (&rect, fb_scale, &new_fb_clip_rect);
+
+          cairo_region_union_rectangle (fb_clip_region, &new_fb_clip_rect);
+        }
+      g_free (rects);
 
       if (fb_scale != floorf (fb_scale))
         {
           subpixel_compensation = ceilf (fb_scale);
-          fb_clip_region.x -= subpixel_compensation;
-          fb_clip_region.y -= subpixel_compensation;
-          fb_clip_region.width += 2 * subpixel_compensation;
-          fb_clip_region.height += 2 * subpixel_compensation;
+
+          n_rects = cairo_region_num_rectangles (fb_clip_region);
+          rects = g_newa (cairo_rectangle_int_t, n_rects);
+          for (i = 0; i < n_rects; i++)
+            {
+              cairo_region_get_rectangle (fb_clip_region, i, &rects[i]);
+              rects[i].x -= subpixel_compensation;
+              rects[i].y -= subpixel_compensation;
+              rects[i].width += 2 * subpixel_compensation;
+              rects[i].height += 2 * subpixel_compensation;
+            }
+          cairo_region_destroy (fb_clip_region);
+          fb_clip_region = cairo_region_create_rectangles (rects, n_rects);
         }
     }
   else
     {
-      fb_clip_region = (cairo_rectangle_int_t) { 0 };
+      fb_clip_region = cairo_region_create ();
+      redraw_clip = cairo_region_reference (fb_clip_region);
     }
 
   if (may_use_clipped_redraw &&
@@ -727,16 +759,14 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
   else
     use_clipped_redraw = FALSE;
 
-  clip_region_empty = may_use_clipped_redraw && fb_clip_region.width == 0;
+  clip_region_empty = may_use_clipped_redraw && cairo_region_is_empty (fb_clip_region);
 
   swap_with_damage = FALSE;
   if (has_buffer_age)
     {
       if (use_clipped_redraw && !clip_region_empty)
         {
-          int age, i;
-          cairo_rectangle_int_t *current_fb_damage =
-            &view_priv->damage_history[DAMAGE_HISTORY (view_priv->damage_index++)];
+          int age;
 
           age = cogl_onscreen_get_buffer_age (COGL_ONSCREEN (fb));
 
@@ -744,56 +774,70 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
             {
               ClutterRect rect;
               cairo_rectangle_int_t damage_region;
+              cairo_rectangle_int_t *rects;
+              int n_rects, i;
 
-              *current_fb_damage = fb_clip_region;
+              fill_current_damage_history (view, fb_clip_region);
 
               for (i = 1; i <= age; i++)
                 {
-                  cairo_rectangle_int_t *fb_damage =
-                    &view_priv->damage_history[DAMAGE_HISTORY (view_priv->damage_index - i - 1)];
-
-                  _clutter_util_rectangle_union (&fb_clip_region,
-                                                 fb_damage,
-                                                 &fb_clip_region);
+                  cairo_region_t *fb_damage =
+                    view_priv->damage_history[DAMAGE_HISTORY (view_priv->damage_index - i - 1)];
+                  cairo_region_union (fb_clip_region, fb_damage);
                 }
 
-              /* Update the bounding redraw clip state with the extra damage. */
-              _clutter_util_rect_from_rectangle (&fb_clip_region, &rect);
-              scale_and_clamp_rect (&rect, 1.0f / fb_scale, &damage_region);
-              _clutter_util_rectangle_offset (&damage_region,
-                                              view_rect.x,
-                                              view_rect.y,
-                                              &damage_region);
-              _clutter_util_rectangle_union (&stage_cogl->bounding_redraw_clip,
-                                             &damage_region,
-                                             &stage_cogl->bounding_redraw_clip);
+              /* Update the redraw clip state with the extra damage. */
+              n_rects = cairo_region_num_rectangles (fb_clip_region);
+              rects = g_newa (cairo_rectangle_int_t, n_rects);
+              for (i = 0; i < n_rects; i++)
+                {
+                  cairo_region_get_rectangle (fb_clip_region, i, &rects[i]);
+                  _clutter_util_rect_from_rectangle (&rects[i], &rect);
+                  scale_and_clamp_rect (&rect, 1.0f / fb_scale, &damage_region);
+                  _clutter_util_rectangle_offset (&damage_region,
+                                                  view_rect.x,
+                                                  view_rect.y,
+                                                  &damage_region);
+                  cairo_region_union_rectangle (stage_cogl->redraw_clip,
+                                                &damage_region);
+                }
 
-              CLUTTER_NOTE (CLIPPING, "Reusing back buffer(age=%d) - repairing region: x=%d, y=%d, width=%d, height=%d\n",
+              CLUTTER_NOTE (CLIPPING, "Reusing back buffer(age=%d) - repairing region: num rects: %d\n",
                             age,
-                            fb_clip_region.x,
-                            fb_clip_region.y,
-                            fb_clip_region.width,
-                            fb_clip_region.height);
+                            cairo_region_num_rectangles (fb_clip_region));
 
               swap_with_damage = TRUE;
             }
           else
             {
+              cairo_rectangle_int_t fb_damage;
+
               CLUTTER_NOTE (CLIPPING, "Invalid back buffer(age=%d): forcing full redraw\n", age);
               use_clipped_redraw = FALSE;
-              *current_fb_damage = (cairo_rectangle_int_t) {
+              fb_damage = (cairo_rectangle_int_t) {
                 .x = 0,
                 .y = 0,
-                .width = view_rect.width * fb_scale,
-                .height = view_rect.height * fb_scale
+                .width = ceilf (view_rect.width * fb_scale),
+                .height = ceilf (view_rect.height * fb_scale)
               };
+              fill_current_damage_history_rectangle (view, &fb_damage);
             }
         }
       else if (!use_clipped_redraw)
         {
-          fill_current_damage_history_and_step (view);
+          cairo_rectangle_int_t fb_damage;
+
+          fb_damage = (cairo_rectangle_int_t) {
+            .x = 0,
+            .y = 0,
+            .width = ceilf (view_rect.width * fb_scale),
+            .height = ceilf (view_rect.height * fb_scale)
+          };
+          fill_current_damage_history_rectangle (view, &fb_damage);
         }
     }
+
+  cairo_region_get_extents (fb_clip_region, &clip_rect);
 
   cogl_push_framebuffer (fb);
   if (use_clipped_redraw && clip_region_empty)
@@ -802,11 +846,9 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
     }
   else if (use_clipped_redraw)
     {
-      ClutterRect rect;
       cairo_rectangle_int_t scissor_rect;
-      cairo_rectangle_int_t paint_rect;
 
-      calculate_scissor_region (&fb_clip_region,
+      calculate_scissor_region (&clip_rect,
                                 subpixel_compensation,
                                 fb_width, fb_height,
                                 &scissor_rect);
@@ -826,14 +868,8 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
                                           scissor_rect.width,
                                           scissor_rect.height);
 
-      _clutter_util_rect_from_rectangle (&fb_clip_region, &rect);
-      scale_and_clamp_rect (&rect, 1.0f / fb_scale, &paint_rect);
-      _clutter_util_rectangle_offset (&paint_rect,
-                                      view_rect.x,
-                                      view_rect.y,
-                                      &paint_rect);
+      paint_stage (stage_cogl, view, fb_clip_region);
 
-      paint_stage (stage_cogl, view, &paint_rect);
       cogl_framebuffer_pop_clip (fb);
 
       stage_cogl->using_clipped_redraw = FALSE;
@@ -843,16 +879,17 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
       CLUTTER_NOTE (CLIPPING, "Unclipped stage paint\n");
 
       /* If we are trying to debug redraw issues then we want to pass
-       * the bounding_redraw_clip so it can be visualized */
+       * the redraw_clip so it can be visualized */
       if (G_UNLIKELY (clutter_paint_debug_flags & CLUTTER_DEBUG_DISABLE_CLIPPED_REDRAWS) &&
           may_use_clipped_redraw &&
           !clip_region_empty)
         {
           ClutterRect rect;
+          cairo_region_t *paint_region;
           cairo_rectangle_int_t scissor_rect;
           cairo_rectangle_int_t paint_rect;
 
-          calculate_scissor_region (&fb_clip_region,
+          calculate_scissor_region (&clip_rect,
                                     subpixel_compensation,
                                     fb_width, fb_height,
                                     &scissor_rect);
@@ -863,20 +900,30 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
                                               scissor_rect.width,
                                               scissor_rect.height);
 
-          _clutter_util_rect_from_rectangle (&fb_clip_region, &rect);
+          _clutter_util_rect_from_rectangle (&clip_rect, &rect);
           scale_and_clamp_rect (&rect, 1.0f / fb_scale, &paint_rect);
           _clutter_util_rectangle_offset (&paint_rect,
                                           view_rect.x,
                                           view_rect.y,
                                           &paint_rect);
 
-          paint_stage (stage_cogl, view, &paint_rect);
+          paint_region = cairo_region_create_rectangle (&paint_rect);
+          paint_stage (stage_cogl, view, paint_region);
+          cairo_region_destroy (paint_region);
           cogl_framebuffer_pop_clip (fb);
         }
       else
-        paint_stage (stage_cogl, view, &view_rect);
+        {
+          cairo_region_t *view_region;
+
+          view_region = cairo_region_create_rectangle (&view_rect);
+          paint_stage (stage_cogl, view, view_region);
+          cairo_region_destroy (view_region);
+        }
     }
   cogl_pop_framebuffer ();
+
+  cairo_region_get_extents (redraw_clip, &redraw_rect);
 
   if (may_use_clipped_redraw &&
       G_UNLIKELY ((clutter_paint_debug_flags & CLUTTER_DEBUG_REDRAWS)))
@@ -884,10 +931,10 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
       CoglContext *ctx = cogl_framebuffer_get_context (fb);
       static CoglPipeline *outline = NULL;
       ClutterActor *actor = CLUTTER_ACTOR (wrapper);
-      float x_1 = redraw_clip.x;
-      float x_2 = redraw_clip.x + redraw_clip.width;
-      float y_1 = redraw_clip.y;
-      float y_2 = redraw_clip.y + redraw_clip.height;
+      float x_1 = redraw_rect.x;
+      float x_2 = redraw_rect.x + redraw_rect.width;
+      float y_1 = redraw_rect.y;
+      float y_2 = redraw_rect.y + redraw_rect.height;
       CoglVertexP2 quad[4] = {
         { x_1, y_1 },
         { x_2, y_1 },
@@ -933,7 +980,7 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
         }
       else
         {
-          swap_region = fb_clip_region;
+          cairo_region_get_extents (fb_clip_region, &swap_region);
           g_assert (swap_region.width > 0);
           do_swap_buffer = TRUE;
         }
@@ -943,6 +990,11 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
       swap_region = (cairo_rectangle_int_t) { 0 };
       do_swap_buffer = TRUE;
     }
+
+  if (redraw_clip)
+    cairo_region_destroy (redraw_clip);
+  if (fb_clip_region)
+    cairo_region_destroy (fb_clip_region);
 
   if (do_swap_buffer)
     {
@@ -998,6 +1050,7 @@ clutter_stage_cogl_redraw (ClutterStageWindow *stage_window)
 
   /* reset the redraw clipping for the next paint... */
   stage_cogl->initialized_redraw_clip = FALSE;
+  g_clear_pointer (&stage_cogl->redraw_clip, cairo_region_destroy);
 
   stage_cogl->frame_count++;
 
@@ -1019,7 +1072,7 @@ clutter_stage_window_iface_init (ClutterStageWindowInterface *iface)
   iface->add_redraw_clip = clutter_stage_cogl_add_redraw_clip;
   iface->has_redraw_clips = clutter_stage_cogl_has_redraw_clips;
   iface->ignoring_redraw_clips = clutter_stage_cogl_ignoring_redraw_clips;
-  iface->get_redraw_clip_bounds = clutter_stage_cogl_get_redraw_clip_bounds;
+  iface->get_redraw_clip = clutter_stage_cogl_get_redraw_clip;
   iface->redraw = clutter_stage_cogl_redraw;
 }
 

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -563,11 +563,7 @@ paint_stage (ClutterStageCogl            *stage_cogl,
   _clutter_stage_maybe_setup_viewport (stage, view);
   _clutter_stage_paint_view (stage, view, &paint_rect);
 
-  if (clutter_stage_view_get_onscreen (view) !=
-      clutter_stage_view_get_framebuffer (view))
-    {
-      clutter_stage_view_blit_offscreen (view, &paint_rect);
-    }
+  clutter_stage_view_after_paint (view, &paint_rect);
 }
 
 static void

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -525,22 +525,48 @@ swap_framebuffer (ClutterStageWindow *stage_window,
 }
 
 static void
+scale_and_clamp_rect (const ClutterRect     *rect,
+                      float                  scale,
+                      cairo_rectangle_int_t *dest)
+
+{
+  ClutterRect tmp = *rect;
+
+  clutter_rect_scale (&tmp, scale, scale);
+  _clutter_util_rectangle_int_extents (&tmp, dest);
+}
+
+static void
 paint_stage (ClutterStageCogl            *stage_cogl,
              ClutterStageView            *view,
              cairo_region_t              *clip)
 {
   ClutterStage *stage = stage_cogl->wrapper;
   cairo_rectangle_int_t clip_rect;
+  cairo_rectangle_int_t paint_rect;
+  cairo_rectangle_int_t view_rect;
+  ClutterRect rect;
+  float fb_scale;
+
+  clutter_stage_view_get_layout (view, &view_rect);
+  fb_scale = clutter_stage_view_get_scale (view);
 
   cairo_region_get_extents (clip, &clip_rect);
 
+  _clutter_util_rect_from_rectangle (&clip_rect, &rect);
+  scale_and_clamp_rect (&rect, 1.0f / fb_scale, &paint_rect);
+  _clutter_util_rectangle_offset (&paint_rect,
+                                  view_rect.x,
+                                  view_rect.y,
+                                  &paint_rect);
+
   _clutter_stage_maybe_setup_viewport (stage, view);
-  _clutter_stage_paint_view (stage, view, &clip_rect);
+  _clutter_stage_paint_view (stage, view, &paint_rect);
 
   if (clutter_stage_view_get_onscreen (view) !=
       clutter_stage_view_get_framebuffer (view))
     {
-      clutter_stage_view_blit_offscreen (view, &clip_rect);
+      clutter_stage_view_blit_offscreen (view, &paint_rect);
     }
 }
 
@@ -651,18 +677,6 @@ is_buffer_age_enabled (void)
          cogl_clutter_winsys_has_feature (COGL_WINSYS_FEATURE_BUFFER_AGE);
 }
 
-static void
-scale_and_clamp_rect (const ClutterRect     *rect,
-                      float                  scale,
-                      cairo_rectangle_int_t *dest)
-
-{
-  ClutterRect tmp = *rect;
-
-  clutter_rect_scale (&tmp, scale, scale);
-  _clutter_util_rectangle_int_extents (&tmp, dest);
-}
-
 static gboolean
 clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
                                 ClutterStageView   *view)
@@ -684,7 +698,6 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
   cairo_region_t *redraw_clip;
   cairo_region_t *fb_clip_region;
   cairo_region_t *swap_region;
-  cairo_rectangle_int_t clip_rect;
   cairo_rectangle_int_t redraw_rect;
   gboolean clip_region_empty;
   float fb_scale;
@@ -860,8 +873,6 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
         }
     }
 
-  cairo_region_get_extents (fb_clip_region, &clip_rect);
-
   cogl_push_framebuffer (fb);
   if (use_clipped_redraw && clip_region_empty)
     {
@@ -869,7 +880,10 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
     }
   else if (use_clipped_redraw)
     {
+      cairo_rectangle_int_t clip_rect;
       cairo_rectangle_int_t scissor_rect;
+
+      cairo_region_get_extents (fb_clip_region, &clip_rect);
 
       calculate_scissor_region (&clip_rect,
                                 subpixel_compensation,
@@ -907,10 +921,10 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
           may_use_clipped_redraw &&
           !clip_region_empty)
         {
-          ClutterRect rect;
-          cairo_region_t *paint_region;
+          cairo_rectangle_int_t clip_rect;
           cairo_rectangle_int_t scissor_rect;
-          cairo_rectangle_int_t paint_rect;
+
+          cairo_region_get_extents (fb_clip_region, &clip_rect);
 
           calculate_scissor_region (&clip_rect,
                                     subpixel_compensation,
@@ -923,16 +937,8 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
                                               scissor_rect.width,
                                               scissor_rect.height);
 
-          _clutter_util_rect_from_rectangle (&clip_rect, &rect);
-          scale_and_clamp_rect (&rect, 1.0f / fb_scale, &paint_rect);
-          _clutter_util_rectangle_offset (&paint_rect,
-                                          view_rect.x,
-                                          view_rect.y,
-                                          &paint_rect);
+          paint_stage (stage_cogl, view, fb_clip_region);
 
-          paint_region = cairo_region_create_rectangle (&paint_rect);
-          paint_stage (stage_cogl, view, paint_region);
-          cairo_region_destroy (paint_region);
           cogl_framebuffer_pop_clip (fb);
         }
       else

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -393,42 +393,49 @@ valid_buffer_age (ClutterStageViewCogl *view_cogl,
 }
 
 static void
-paint_damage_region (ClutterStageWindow    *stage_window,
-                     ClutterStageView      *view,
-                     cairo_rectangle_int_t *swap_region)
+paint_damage_region (ClutterStageWindow *stage_window,
+                     ClutterStageView   *view,
+                     cairo_region_t     *swap_region)
 {
   CoglFramebuffer *framebuffer = clutter_stage_view_get_onscreen (view);
   CoglContext *ctx = cogl_framebuffer_get_context (framebuffer);
   static CoglPipeline *overlay_blue = NULL;
   ClutterStageCogl *stage_cogl = CLUTTER_STAGE_COGL (stage_window);
   ClutterActor *actor = CLUTTER_ACTOR (stage_cogl->wrapper);
-  float x_1 = swap_region->x;
-  float x_2 = swap_region->x + swap_region->width;
-  float y_1 = swap_region->y;
-  float y_2 = swap_region->y + swap_region->height;
-  CoglMatrix modelview;
+  CoglMatrix transform;
+  int n_rects, i;
 
+  cogl_framebuffer_push_matrix (framebuffer);
+  clutter_actor_get_transform (actor, &transform);
+  cogl_framebuffer_transform (framebuffer, &transform);
+
+  /* Blue for the swap region */
   if (G_UNLIKELY (overlay_blue == NULL))
     {
       overlay_blue = cogl_pipeline_new (ctx);
       cogl_pipeline_set_color4ub (overlay_blue, 0x00, 0x00, 0x33, 0x33);
     }
 
-  cogl_framebuffer_push_matrix (framebuffer);
-  cogl_matrix_init_identity (&modelview);
-  _clutter_actor_apply_modelview_transform (actor, &modelview);
-  cogl_framebuffer_set_modelview_matrix (framebuffer, &modelview);
+  n_rects = cairo_region_num_rectangles (swap_region);
+  for (i = 0; i < n_rects; i++)
+    {
+      cairo_rectangle_int_t rect;
+      float x_1, x_2, y_1, y_2;
 
-  /* Blue for the swap region */
-  cogl_framebuffer_draw_rectangle (framebuffer, overlay_blue, x_1, y_1, x_2, y_2);
+      cairo_region_get_rectangle (swap_region, i, &rect);
+      x_1 = rect.x;
+      x_2 = rect.x + rect.width;
+      y_1 = rect.y;
+      y_2 = rect.y + rect.height;
+
+      cogl_framebuffer_draw_rectangle (framebuffer, overlay_blue, x_1, y_1, x_2, y_2);
+    }
 
   /* Red for the clip */
   if (stage_cogl->initialized_redraw_clip &&
       stage_cogl->redraw_clip)
     {
       static CoglPipeline *overlay_red = NULL;
-      cairo_rectangle_int_t *rects;
-      int n_rects, i;
 
       if (G_UNLIKELY (overlay_red == NULL))
         {
@@ -439,11 +446,14 @@ paint_damage_region (ClutterStageWindow    *stage_window,
       n_rects = cairo_region_num_rectangles (stage_cogl->redraw_clip);
       for (i = 0; i < n_rects; i++)
         {
-          cairo_region_get_rectangle (stage_cogl->redraw_clip, i, &rects[i]);
-          x_1 = rects[i].x;
-          x_2 = rects[i].x + rects[i].width;
-          y_1 = rects[i].y;
-          y_2 = rects[i].y + rects[i].height;
+          cairo_rectangle_int_t rect;
+          float x_1, x_2, y_1, y_2;
+
+          cairo_region_get_rectangle (stage_cogl->redraw_clip, i, &rect);
+          x_1 = rect.x;
+          x_2 = rect.x + rect.width;
+          y_1 = rect.y;
+          y_2 = rect.y + rect.height;
 
           cogl_framebuffer_draw_rectangle (framebuffer, overlay_red, x_1, y_1, x_2, y_2);
         }
@@ -453,43 +463,43 @@ paint_damage_region (ClutterStageWindow    *stage_window,
 }
 
 static gboolean
-swap_framebuffer (ClutterStageWindow    *stage_window,
-                  ClutterStageView      *view,
-                  cairo_rectangle_int_t *swap_region,
-                  gboolean               swap_with_damage)
+swap_framebuffer (ClutterStageWindow *stage_window,
+                  ClutterStageView   *view,
+                  cairo_region_t     *swap_region,
+                  gboolean            swap_with_damage)
 {
   CoglFramebuffer *framebuffer = clutter_stage_view_get_onscreen (view);
-  int damage[4], ndamage;
-
-  damage[0] = swap_region->x;
-  damage[1] = swap_region->y;
-  damage[2] = swap_region->width;
-  damage[3] = swap_region->height;
-
-  if (swap_region->width != 0)
-    ndamage = 1;
-  else
-    ndamage = 0;
+  int *damage, n_rects, i;
 
   if (G_UNLIKELY ((clutter_paint_debug_flags & CLUTTER_DEBUG_PAINT_DAMAGE_REGION)))
     paint_damage_region (stage_window, view, swap_region);
+
+  n_rects = cairo_region_num_rectangles (swap_region);
+  damage = g_newa (int, n_rects * 4);
+  for (i = 0; i < n_rects; i++)
+    {
+      cairo_rectangle_int_t rect;
+
+      cairo_region_get_rectangle (swap_region, i, &rect);
+      damage[i * 4] = rect.x;
+      damage[i * 4 + 1] = rect.y;
+      damage[i * 4 + 2] = rect.width;
+      damage[i * 4 + 3] = rect.height;
+    }
 
   if (cogl_is_onscreen (framebuffer))
     {
       CoglOnscreen *onscreen = COGL_ONSCREEN (framebuffer);
 
       /* push on the screen */
-      if (ndamage == 1 && !swap_with_damage)
+      if (n_rects > 0 && !swap_with_damage)
         {
           CLUTTER_NOTE (BACKEND,
-                        "cogl_onscreen_swap_region (onscreen: %p, "
-                        "x: %d, y: %d, "
-                        "width: %d, height: %d)",
-                        onscreen,
-                        damage[0], damage[1], damage[2], damage[3]);
+                        "cogl_onscreen_swap_region (onscreen: %p)",
+                        onscreen);
 
           cogl_onscreen_swap_region (onscreen,
-                                     damage, ndamage);
+                                     damage, n_rects);
 
           return FALSE;
         }
@@ -499,7 +509,7 @@ swap_framebuffer (ClutterStageWindow    *stage_window,
                         onscreen);
 
           cogl_onscreen_swap_buffers_with_damage (onscreen,
-                                                  damage, ndamage);
+                                                  damage, n_rects);
 
           return TRUE;
         }
@@ -562,40 +572,52 @@ fill_current_damage_history_rectangle (ClutterStageView            *view,
   cairo_region_destroy (damage);
 }
 
-static void
-transform_swap_region_to_onscreen (ClutterStageView      *view,
-                                   cairo_rectangle_int_t *swap_region)
+static cairo_region_t *
+transform_swap_region_to_onscreen (ClutterStageView *view,
+                                   cairo_region_t   *swap_region)
 {
   CoglFramebuffer *framebuffer;
   cairo_rectangle_int_t layout;
-  gfloat x1, y1, x2, y2;
   gint width, height;
+  int n_rects, i;
+  cairo_rectangle_int_t *rects;
+  cairo_region_t *transformed_region;
 
   framebuffer = clutter_stage_view_get_onscreen (view);
   clutter_stage_view_get_layout (view, &layout);
 
-  x1 = (float) swap_region->x / layout.width;
-  y1 = (float) swap_region->y / layout.height;
-  x2 = (float) (swap_region->x + swap_region->width) / layout.width;
-  y2 = (float) (swap_region->y + swap_region->height) / layout.height;
-
-  clutter_stage_view_transform_to_onscreen (view, &x1, &y1);
-  clutter_stage_view_transform_to_onscreen (view, &x2, &y2);
-
   width = cogl_framebuffer_get_width (framebuffer);
   height = cogl_framebuffer_get_height (framebuffer);
 
-  x1 = floor (x1 * width);
-  y1 = floor (height - (y1 * height));
-  x2 = ceil (x2 * width);
-  y2 = ceil (height - (y2 * height));
+  n_rects = cairo_region_num_rectangles (swap_region);
+  rects = g_newa (cairo_rectangle_int_t, n_rects);
+  for (i = 0; i < n_rects; i++)
+    {
+      gfloat x1, y1, x2, y2;
 
-  *swap_region = (cairo_rectangle_int_t) {
-    .x = x1,
-    .y = y1,
-    .width = x2 - x1,
-    .height = y2 - y1
-  };
+      cairo_region_get_rectangle (swap_region, i, &rects[i]);
+
+      x1 = (float) rects[i].x / layout.width;
+      y1 = (float) rects[i].y / layout.height;
+      x2 = (float) (rects[i].x + rects[i].width) / layout.width;
+      y2 = (float) (rects[i].y + rects[i].height) / layout.height;
+
+      clutter_stage_view_transform_to_onscreen (view, &x1, &y1);
+      clutter_stage_view_transform_to_onscreen (view, &x2, &y2);
+
+      x1 = floor (x1 * width);
+      y1 = floor (height - (y1 * height));
+      x2 = ceil (x2 * width);
+      y2 = ceil (height - (y2 * height));
+
+      rects[i].x = x1;
+      rects[i].y = y1;
+      rects[i].width = x2 - x1;
+      rects[i].height = y2 - y1;
+    }
+  transformed_region = cairo_region_create_rectangles (rects, n_rects);
+
+  return transformed_region;
 }
 
 static void
@@ -661,7 +683,7 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
   ClutterActor *wrapper;
   cairo_region_t *redraw_clip;
   cairo_region_t *fb_clip_region;
-  cairo_rectangle_int_t swap_region;
+  cairo_region_t *swap_region;
   cairo_rectangle_int_t clip_rect;
   cairo_rectangle_int_t redraw_rect;
   gboolean clip_region_empty;
@@ -980,14 +1002,13 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
         }
       else
         {
-          cairo_region_get_extents (fb_clip_region, &swap_region);
-          g_assert (swap_region.width > 0);
+          swap_region = cairo_region_copy (fb_clip_region);
           do_swap_buffer = TRUE;
         }
     }
   else
     {
-      swap_region = (cairo_rectangle_int_t) { 0 };
+      swap_region = cairo_region_create ();
       do_swap_buffer = TRUE;
     }
 
@@ -998,19 +1019,30 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
 
   if (do_swap_buffer)
     {
+      gboolean res;
+
       COGL_TRACE_BEGIN_SCOPED (ClutterStageCoglRedrawViewSwapFramebuffer,
                                "Paint (swap framebuffer)");
 
       if (clutter_stage_view_get_onscreen (view) !=
           clutter_stage_view_get_framebuffer (view))
         {
-          transform_swap_region_to_onscreen (view, &swap_region);
+          cairo_region_t *transformed_swap_region;
+
+          transformed_swap_region =
+            transform_swap_region_to_onscreen (view, swap_region);
+          cairo_region_destroy (swap_region);
+          swap_region = transformed_swap_region;
         }
 
-      return swap_framebuffer (stage_window,
-                               view,
-                               &swap_region,
-                               swap_with_damage);
+      res = swap_framebuffer (stage_window,
+                              view,
+                              swap_region,
+                              swap_with_damage);
+
+      cairo_region_destroy (swap_region);
+
+      return res;
     }
   else
     {

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -771,8 +771,9 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
     }
   else
     {
-      fb_clip_region = cairo_region_create ();
-      redraw_clip = cairo_region_reference (fb_clip_region);
+      cairo_rectangle_int_t rect = { 0, 0, view_rect.width, view_rect.height };
+      fb_clip_region = cairo_region_create_rectangle (&rect);
+      redraw_clip = cairo_region_copy (fb_clip_region);
     }
 
   if (may_use_clipped_redraw &&

--- a/clutter/clutter/cogl/clutter-stage-cogl.h
+++ b/clutter/clutter/cogl/clutter-stage-cogl.h
@@ -62,7 +62,7 @@ struct _ClutterStageCogl
 
   gint last_sync_delay;
 
-  cairo_rectangle_int_t bounding_redraw_clip;
+  cairo_region_t *redraw_clip;
 
   guint initialized_redraw_clip : 1;
 

--- a/cogl/cogl/cogl-clip-stack.c
+++ b/cogl/cogl/cogl-clip-stack.c
@@ -297,6 +297,30 @@ _cogl_clip_stack_push_primitive (CoglClipStack *stack,
 }
 
 CoglClipStack *
+cogl_clip_stack_push_region (CoglClipStack   *stack,
+                             cairo_region_t  *region)
+{
+  CoglClipStack *entry;
+  CoglClipStackRegion *entry_region;
+  cairo_rectangle_int_t bounds;
+
+  entry_region = _cogl_clip_stack_push_entry (stack,
+                                              sizeof (CoglClipStackRegion),
+                                              COGL_CLIP_STACK_REGION);
+  entry = (CoglClipStack *) entry_region;
+
+  cairo_region_get_extents (region, &bounds);
+  entry->bounds_x0 = bounds.x;
+  entry->bounds_x1 = bounds.x + bounds.width;
+  entry->bounds_y0 = bounds.y;
+  entry->bounds_y1 = bounds.y + bounds.height;
+
+  entry_region->region = cairo_region_reference (region);
+
+  return entry;
+}
+
+CoglClipStack *
 _cogl_clip_stack_ref (CoglClipStack *entry)
 {
   /* A NULL pointer is considered a valid stack so we should accept
@@ -335,6 +359,13 @@ _cogl_clip_stack_unref (CoglClipStack *entry)
             cogl_matrix_entry_unref (primitive_entry->matrix_entry);
             cogl_object_unref (primitive_entry->primitive);
             g_slice_free1 (sizeof (CoglClipStackPrimitive), entry);
+            break;
+          }
+        case COGL_CLIP_STACK_REGION:
+          {
+            CoglClipStackRegion *region = (CoglClipStackRegion *) entry;
+            cairo_region_destroy (region->region);
+            g_slice_free1 (sizeof (CoglClipStackRegion), entry);
             break;
           }
         default:

--- a/cogl/cogl/cogl-clip-stack.h
+++ b/cogl/cogl/cogl-clip-stack.h
@@ -48,12 +48,14 @@ typedef struct _CoglClipStack CoglClipStack;
 typedef struct _CoglClipStackRect CoglClipStackRect;
 typedef struct _CoglClipStackWindowRect CoglClipStackWindowRect;
 typedef struct _CoglClipStackPrimitive CoglClipStackPrimitive;
+typedef struct _CoglClipStackRegion CoglClipStackRegion;
 
 typedef enum
   {
     COGL_CLIP_STACK_RECT,
     COGL_CLIP_STACK_WINDOW_RECT,
-    COGL_CLIP_STACK_PRIMITIVE
+    COGL_CLIP_STACK_PRIMITIVE,
+    COGL_CLIP_STACK_REGION,
   } CoglClipStackType;
 
 /* A clip stack consists a list of entries. Each entry has a reference
@@ -162,6 +164,13 @@ struct _CoglClipStackPrimitive
   float bounds_y2;
 };
 
+struct _CoglClipStackRegion
+{
+  CoglClipStack _parent_data;
+
+  cairo_region_t *region;
+};
+
 CoglClipStack *
 _cogl_clip_stack_push_window_rectangle (CoglClipStack *stack,
                                         int x_offset,
@@ -189,6 +198,9 @@ _cogl_clip_stack_push_primitive (CoglClipStack *stack,
                                  CoglMatrixEntry *modelview_entry,
                                  CoglMatrixEntry *projection_entry,
                                  const float *viewport);
+CoglClipStack *
+cogl_clip_stack_push_region (CoglClipStack   *stack,
+                             cairo_region_t  *region);
 
 CoglClipStack *
 _cogl_clip_stack_pop (CoglClipStack *stack);

--- a/cogl/cogl/cogl-context-private.h
+++ b/cogl/cogl/cogl-context-private.h
@@ -275,11 +275,6 @@ struct _CoglContext
      same state multiple times. When the clip state is flushed this
      will hold a reference */
   CoglClipStack    *current_clip_stack;
-  /* Whether the stencil buffer was used as part of the current clip
-     state. If TRUE then any further use of the stencil buffer (such
-     as for drawing paths) would need to be merged with the existing
-     stencil buffer */
-  gboolean          current_clip_stack_uses_stencil;
 
   /* This is used as a temporary buffer to fill a CoglBuffer when
      cogl_buffer_map fails and we only want to map to fill it with new

--- a/cogl/cogl/cogl-framebuffer.c
+++ b/cogl/cogl/cogl-framebuffer.c
@@ -1823,6 +1823,19 @@ cogl_framebuffer_push_primitive_clip (CoglFramebuffer *framebuffer,
 }
 
 void
+cogl_framebuffer_push_region_clip (CoglFramebuffer *framebuffer,
+                                   cairo_region_t  *region)
+{
+  framebuffer->clip_stack =
+    cogl_clip_stack_push_region (framebuffer->clip_stack,
+                                 region);
+
+  if (framebuffer->context->current_draw_buffer == framebuffer)
+    framebuffer->context->current_draw_buffer_changes |=
+      COGL_FRAMEBUFFER_STATE_CLIP;
+}
+
+void
 cogl_framebuffer_pop_clip (CoglFramebuffer *framebuffer)
 {
   framebuffer->clip_stack = _cogl_clip_stack_pop (framebuffer->clip_stack);

--- a/cogl/cogl/cogl-framebuffer.h
+++ b/cogl/cogl/cogl-framebuffer.h
@@ -56,6 +56,7 @@ typedef struct _CoglFramebuffer CoglFramebuffer;
 #include <cogl/cogl-euler.h>
 #include <cogl/cogl-texture.h>
 #include <glib-object.h>
+#include <cairo.h>
 
 G_BEGIN_DECLS
 
@@ -638,6 +639,10 @@ cogl_framebuffer_push_primitive_clip (CoglFramebuffer *framebuffer,
                                       float bounds_y1,
                                       float bounds_x2,
                                       float bounds_y2);
+
+void
+cogl_framebuffer_push_region_clip (CoglFramebuffer *framebuffer,
+                                   cairo_region_t  *region);
 
 /**
  * cogl_framebuffer_pop_clip:

--- a/cogl/cogl/cogl-primitives-private.h
+++ b/cogl/cogl/cogl-primitives-private.h
@@ -47,6 +47,13 @@ _cogl_rectangle_immediate (CoglFramebuffer *framebuffer,
                            float x_2,
                            float y_2);
 
+void
+cogl_2d_primitives_immediate (CoglFramebuffer *framebuffer,
+                              CoglPipeline *pipeline,
+                              CoglVerticesMode mode,
+                              const CoglVertexP2 *vertices,
+                              unsigned int n_vertices);
+
 typedef struct _CoglMultiTexturedRect
 {
   const float *position; /* x0,y0,x1,y1 */

--- a/cogl/cogl/cogl-primitives.c
+++ b/cogl/cogl/cogl-primitives.c
@@ -853,42 +853,31 @@ cogl_rectangle (float x_1,
 }
 
 void
-_cogl_rectangle_immediate (CoglFramebuffer *framebuffer,
-                           CoglPipeline *pipeline,
-                           float x_1,
-                           float y_1,
-                           float x_2,
-                           float y_2)
+cogl_2d_primitives_immediate (CoglFramebuffer *framebuffer,
+                              CoglPipeline *pipeline,
+                              CoglVerticesMode mode,
+                              const CoglVertexP2 *vertices,
+                              unsigned int n_vertices)
 {
-  /* Draw a rectangle using the vertex array API to avoid going
-     through the journal. This should only be used in cases where the
-     code might be called while the journal is already being flushed
-     such as when flushing the clip state */
   CoglContext *ctx = framebuffer->context;
-  float vertices[8] =
-    {
-      x_1, y_1,
-      x_1, y_2,
-      x_2, y_1,
-      x_2, y_2
-    };
   CoglAttributeBuffer *attribute_buffer;
   CoglAttribute *attributes[1];
+  size_t vertices_size = sizeof (CoglVertexP2) * n_vertices;
 
   attribute_buffer =
-    cogl_attribute_buffer_new (ctx, sizeof (vertices), vertices);
+    cogl_attribute_buffer_new (ctx, vertices_size, vertices);
   attributes[0] = cogl_attribute_new (attribute_buffer,
                                       "cogl_position_in",
-                                      sizeof (float) * 2, /* stride */
+                                      sizeof (CoglVertexP2), /* stride */
                                       0, /* offset */
                                       2, /* n_components */
                                       COGL_ATTRIBUTE_TYPE_FLOAT);
 
   _cogl_framebuffer_draw_attributes (framebuffer,
                                      pipeline,
-                                     COGL_VERTICES_MODE_TRIANGLE_STRIP,
+                                     mode,
                                      0, /* first_index */
-                                     4, /* n_vertices */
+                                     n_vertices,
                                      attributes,
                                      1,
                                      COGL_DRAW_SKIP_JOURNAL_FLUSH |
@@ -1139,4 +1128,27 @@ cogl_polygon (const CoglTextureVertex *vertices,
 
   for (i = 0; i < n_attributes; i++)
     cogl_object_unref (attributes[i]);
+}
+
+void
+_cogl_rectangle_immediate (CoglFramebuffer *framebuffer,
+                           CoglPipeline *pipeline,
+                           float x_1,
+                           float y_1,
+                           float x_2,
+                           float y_2)
+{
+  CoglVertexP2 vertices[4] =
+    {
+      {x_1, y_1},
+      {x_1, y_2},
+      {x_2, y_1},
+      {x_2, y_2}
+    };
+
+  cogl_2d_primitives_immediate (framebuffer,
+                                pipeline,
+                                COGL_VERTICES_MODE_TRIANGLE_STRIP,
+                                vertices,
+                                4);
 }

--- a/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
+++ b/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
@@ -260,6 +260,102 @@ add_stencil_clip_rectangle (CoglFramebuffer *framebuffer,
   GE( ctx, glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP) );
 }
 
+static void
+add_stencil_clip_region (CoglFramebuffer *framebuffer,
+                         cairo_region_t  *region,
+                         gboolean         merge)
+{
+  CoglContext *ctx = cogl_framebuffer_get_context (framebuffer);
+  CoglMatrix matrix;
+  int num_rectangles = cairo_region_num_rectangles (region);
+  int i;
+
+  /* NB: This can be called while flushing the journal so we need
+   * to be very conservative with what state we change.
+   */
+  _cogl_context_set_current_projection_entry (ctx, &ctx->identity_entry);
+  _cogl_context_set_current_modelview_entry (ctx, &ctx->identity_entry);
+
+  /* The coordinates in the region are meant to be window coordinates,
+   * make a matrix that translates those across the viewport, and into
+   * the default [-1, -1, 1, 1] range.
+   */
+  cogl_matrix_init_identity (&matrix);
+  cogl_matrix_translate (&matrix, -1, 1, 0);
+  cogl_matrix_scale (&matrix,
+                     2.0 / framebuffer->viewport_width,
+                     - 2.0 / framebuffer->viewport_height,
+                     1);
+  cogl_matrix_translate (&matrix,
+                         - framebuffer->viewport_x,
+                         - framebuffer->viewport_y,
+                         0);
+
+  GE( ctx, glEnable (GL_STENCIL_TEST) );
+
+  GE( ctx, glColorMask (FALSE, FALSE, FALSE, FALSE) );
+  GE( ctx, glDepthMask (FALSE) );
+
+  if (merge)
+    {
+      GE( ctx, glStencilFunc (GL_ALWAYS, 0x1, 0x3) );
+      GE( ctx, glStencilOp (GL_KEEP, GL_KEEP, GL_INCR) );
+    }
+  else
+    {
+      /* Initially disallow everything */
+      GE( ctx, glClearStencil (0) );
+      GE( ctx, glClear (GL_STENCIL_BUFFER_BIT) );
+
+      /* Punch out holes to allow the rectangles */
+      GE( ctx, glStencilFunc (GL_ALWAYS, 0x1, 0x1) );
+      GE( ctx, glStencilOp (GL_KEEP, GL_KEEP, GL_REPLACE) );
+    }
+
+  for (i = 0; i < num_rectangles; i++)
+    {
+      cairo_rectangle_int_t rect;
+      float tl[4], br[4];
+
+      cairo_region_get_rectangle (region, i, &rect);
+
+      tl[0] = rect.x;
+      tl[1] = rect.y;
+      tl[2] = 0.;
+      tl[3] = 1.;
+
+      br[0] = rect.x + rect.width;
+      br[1] = rect.y + rect.height;
+      br[2] = 0.;
+      br[3] = 1.;
+
+      cogl_matrix_transform_point (&matrix, &tl[0], &tl[1], &tl[2], &tl[3]);
+      cogl_matrix_transform_point (&matrix, &br[0], &br[1], &br[2], &br[3]);
+
+      _cogl_rectangle_immediate (framebuffer,
+                                 ctx->stencil_pipeline,
+                                 tl[0], tl[1], br[0], br[1]);
+    }
+
+  if (merge)
+    {
+      /* Subtract one from all pixels in the stencil buffer so that
+       * only pixels where both the original stencil buffer and the
+       * region are set will be valid
+       */
+      GE( ctx, glStencilOp (GL_KEEP, GL_KEEP, GL_DECR) );
+      _cogl_rectangle_immediate (framebuffer,
+                                 ctx->stencil_pipeline,
+                                 -1.0, -1.0, 1.0, 1.0);
+    }
+
+  /* Restore the stencil mode */
+  GE (ctx, glDepthMask (TRUE));
+  GE (ctx, glColorMask (TRUE, TRUE, TRUE, TRUE));
+  GE( ctx, glStencilFunc (GL_EQUAL, 0x1, 0x1) );
+  GE( ctx, glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP) );
+}
+
 typedef void (*SilhouettePaintCallback) (CoglFramebuffer *framebuffer,
                                          CoglPipeline *pipeline,
                                          void *user_data);
@@ -569,6 +665,23 @@ _cogl_clip_stack_gl_flush (CoglClipStack *stack,
                                                   !using_stencil_buffer);
                       using_stencil_buffer = TRUE;
                     }
+                }
+              break;
+            }
+        case COGL_CLIP_STACK_REGION:
+            {
+              CoglClipStackRegion *region = (CoglClipStackRegion *) entry;
+
+              /* If nrectangles <= 1, it can be fully represented with the
+               * scissor clip.
+               */
+              if (cairo_region_num_rectangles (region->region) > 1)
+                {
+                  COGL_NOTE (CLIPPING, "Adding stencil clip for region");
+
+                  add_stencil_clip_region (framebuffer, region->region,
+                                           using_stencil_buffer);
+                  using_stencil_buffer = TRUE;
                 }
               break;
             }

--- a/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
+++ b/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
@@ -315,26 +315,27 @@ add_stencil_clip_region (CoglFramebuffer *framebuffer,
   for (i = 0; i < num_rectangles; i++)
     {
       cairo_rectangle_int_t rect;
-      float tl[4], br[4];
+      float x1, y1, z1, w1;
+      float x2, y2, z2, w2;
 
       cairo_region_get_rectangle (region, i, &rect);
 
-      tl[0] = rect.x;
-      tl[1] = rect.y;
-      tl[2] = 0.;
-      tl[3] = 1.;
+      x1 = rect.x;
+      y1 = rect.y;
+      z1 = 0.f;
+      w1 = 1.f;
 
-      br[0] = rect.x + rect.width;
-      br[1] = rect.y + rect.height;
-      br[2] = 0.;
-      br[3] = 1.;
+      x2 = rect.x + rect.width;
+      y2 = rect.y + rect.height;
+      z2 = 0.f;
+      w2 = 1.f;
 
-      cogl_matrix_transform_point (&matrix, &tl[0], &tl[1], &tl[2], &tl[3]);
-      cogl_matrix_transform_point (&matrix, &br[0], &br[1], &br[2], &br[3]);
+      cogl_matrix_transform_point (&matrix, &x1, &y1, &z1, &w1);
+      cogl_matrix_transform_point (&matrix, &x2, &y2, &z2, &w2);
 
       _cogl_rectangle_immediate (framebuffer,
                                  ctx->stencil_pipeline,
-                                 tl[0], tl[1], br[0], br[1]);
+                                 x1, y1, x2, y2);
     }
 
   if (merge)

--- a/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
+++ b/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
@@ -269,6 +269,7 @@ add_stencil_clip_region (CoglFramebuffer *framebuffer,
   CoglMatrix matrix;
   int num_rectangles = cairo_region_num_rectangles (region);
   int i;
+  CoglVertexP2 *vertices;
 
   /* NB: This can be called while flushing the journal so we need
    * to be very conservative with what state we change.
@@ -312,11 +313,14 @@ add_stencil_clip_region (CoglFramebuffer *framebuffer,
       GE( ctx, glStencilOp (GL_KEEP, GL_KEEP, GL_REPLACE) );
     }
 
+  vertices = g_alloca (sizeof (CoglVertexP2) * num_rectangles * 6);
+
   for (i = 0; i < num_rectangles; i++)
     {
       cairo_rectangle_int_t rect;
       float x1, y1, z1, w1;
       float x2, y2, z2, w2;
+      CoglVertexP2 *v = vertices + i * 6;
 
       cairo_region_get_rectangle (region, i, &rect);
 
@@ -333,10 +337,25 @@ add_stencil_clip_region (CoglFramebuffer *framebuffer,
       cogl_matrix_transform_point (&matrix, &x1, &y1, &z1, &w1);
       cogl_matrix_transform_point (&matrix, &x2, &y2, &z2, &w2);
 
-      _cogl_rectangle_immediate (framebuffer,
-                                 ctx->stencil_pipeline,
-                                 x1, y1, x2, y2);
+      v[0].x = x1;
+      v[0].y = y1;
+      v[1].x = x1;
+      v[1].y = y2;
+      v[2].x = x2;
+      v[2].y = y1;
+      v[3].x = x1;
+      v[3].y = y2;
+      v[4].x = x2;
+      v[4].y = y2;
+      v[5].x = x2;
+      v[5].y = y1;
     }
+
+  cogl_2d_primitives_immediate (framebuffer,
+                                ctx->stencil_pipeline,
+                                COGL_VERTICES_MODE_TRIANGLES,
+                                vertices,
+                                6 * num_rectangles);
 
   if (merge)
     {

--- a/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
+++ b/cogl/cogl/driver/gl/cogl-clip-stack-gl.c
@@ -553,7 +553,6 @@ _cogl_clip_stack_gl_flush (CoglClipStack *stack,
     {
       COGL_NOTE (CLIPPING, "Flushed empty clip stack");
 
-      ctx->current_clip_stack_uses_stencil = FALSE;
       GE (ctx, glDisable (GL_SCISSOR_TEST));
       return;
     }
@@ -697,6 +696,4 @@ _cogl_clip_stack_gl_flush (CoglClipStack *stack,
      setting up the stencil buffer */
   if (using_clip_planes)
     enable_clip_planes (ctx);
-
-  ctx->current_clip_stack_uses_stencil = using_stencil_buffer;
 }

--- a/cogl/cogl/meson.build
+++ b/cogl/cogl/meson.build
@@ -494,7 +494,7 @@ if have_introspection
     sources: cogl_introspected_headers,
     nsversion: libmutter_api_version,
     namespace: 'Cogl',
-    includes: ['GL-1.0', 'GObject-2.0'],
+    includes: ['GL-1.0', 'GL-1.0', 'GObject-2.0'],
     dependencies: [cogl_deps],
     extra_args: introspection_args + [
       '-UCOGL_COMPILATION',

--- a/src/compositor/meta-window-group.c
+++ b/src/compositor/meta-window-group.c
@@ -56,7 +56,7 @@ meta_window_group_paint (ClutterActor *actor)
 {
   cairo_region_t *clip_region;
   cairo_region_t *unobscured_region;
-  cairo_rectangle_int_t visible_rect, clip_rect;
+  cairo_rectangle_int_t visible_rect;
   int paint_x_origin, paint_y_origin;
   int screen_width, screen_height;
 
@@ -112,10 +112,7 @@ meta_window_group_paint (ClutterActor *actor)
    * sizes, we could intersect this with an accurate union of the
    * monitors to avoid painting shadows that are visible only in the
    * holes. */
-  clutter_stage_get_redraw_clip_bounds (CLUTTER_STAGE (stage),
-                                        &clip_rect);
-
-  clip_region = cairo_region_create_rectangle (&clip_rect);
+  clip_region = clutter_stage_get_redraw_clip (CLUTTER_STAGE (stage));
 
   cairo_region_translate (clip_region, -paint_x_origin, -paint_y_origin);
 


### PR DESCRIPTION
This is a series of cherry-picks that helps Endless OS running on RPI4. The 4 major features being cherry-picked here are:

 1. Regional clipping: reduces the amount of swapped regions quite drastically. This brings the biggest  performance improvements.
 2. Separate shadowfb: almost no effect, but it's here anyway.
 3. Pango attr cache: significant improvement text-heavy actors (opening and closing menus, icon grid, etc)
 4. Shallow relayouts: minor improvement, specially when dragging and resizing windows.