### PR TITLE
clutter/click-action: Do not process captured event if action is disabled

### DIFF
--- a/clutter/clutter/clutter-click-action.c
+++ b/clutter/clutter/clutter-click-action.c
@@ -346,6 +346,12 @@ on_captured_event (ClutterActor       *stage,
   ClutterModifierType modifier_state;
   gboolean has_button = TRUE;
 
+  if (!clutter_actor_meta_get_enabled (CLUTTER_ACTOR_META (action)))
+    {
+      clutter_click_action_release (action);
+      return CLUTTER_EVENT_PROPAGATE;
+    }
+
   actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (action));
 
   switch (clutter_event_type (event))


### PR DESCRIPTION
Disabling a click action after a button-press but before a
button-release is captured makes ClutterClickAction connect to
captured-event and never disconnect.

This change fixes it by making sure the captured-event is only
processed if the action is still enabled, otherwise releasing
the action (reset state) and propagating the event.

https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1170

https://phabricator.endlessm.com/T29682