### PR TITLE
3.36 cherry-picks

### DIFF
--- a/clutter/clutter/clutter-actor.c
+++ b/clutter/clutter/clutter-actor.c
@@ -4191,7 +4191,9 @@ clutter_actor_continue_paint (ClutterActor        *self,
       clutter_paint_node_unref (dummy);
 
       /* XXX:2.0 - Call the paint() virtual directly */
-      if (g_signal_has_handler_pending (self, actor_signals[PAINT],
+      if (!(clutter_paint_context_get_paint_flags (paint_context) &
+            CLUTTER_PAINT_FLAG_NO_PAINT_SIGNAL) &&
+          g_signal_has_handler_pending (self, actor_signals[PAINT],
                                         0, TRUE))
         g_signal_emit (self, actor_signals[PAINT], 0, paint_context);
       else

--- a/clutter/clutter/clutter-mutter.h
+++ b/clutter/clutter/clutter-mutter.h
@@ -30,6 +30,7 @@
 #include "clutter-input-device-private.h"
 #include "clutter-input-pointer-a11y-private.h"
 #include "clutter-macros.h"
+#include "clutter-paint-context-private.h"
 #include "clutter-private.h"
 #include "clutter-stage-private.h"
 #include "clutter-stage-view.h"
@@ -47,6 +48,23 @@ void clutter_stage_capture_into (ClutterStage          *stage,
                                  gboolean               paint,
                                  cairo_rectangle_int_t *rect,
                                  uint8_t               *data);
+
+CLUTTER_EXPORT
+void clutter_stage_paint_to_framebuffer (ClutterStage                *stage,
+                                         CoglFramebuffer             *framebuffer,
+                                         const cairo_rectangle_int_t *rect,
+                                         float                        scale,
+                                         ClutterPaintFlag             paint_flags);
+
+CLUTTER_EXPORT
+gboolean clutter_stage_paint_to_buffer (ClutterStage                 *stage,
+                                        const cairo_rectangle_int_t  *rect,
+                                        float                         scale,
+                                        uint8_t                      *data,
+                                        int                           stride,
+                                        CoglPixelFormat               format,
+                                        ClutterPaintFlag              paint_flags,
+                                        GError                      **error);
 
 CLUTTER_EXPORT
 void clutter_stage_freeze_updates (ClutterStage *stage);

--- a/clutter/clutter/clutter-paint-context-private.h
+++ b/clutter/clutter/clutter-paint-context-private.h
@@ -20,11 +20,20 @@
 
 #include "clutter-paint-context.h"
 
+typedef enum _ClutterPaintFlag
+{
+  CLUTTER_PAINT_FLAG_NONE = 0,
+} ClutterPaintFlag;
+
 ClutterPaintContext * clutter_paint_context_new_for_view (ClutterStageView     *view,
-                                                          const cairo_region_t *redraw_clip);
+                                                          const cairo_region_t *redraw_clip,
+                                                          ClutterPaintFlag      paint_flags);
 
 gboolean clutter_paint_context_is_drawing_off_stage (ClutterPaintContext *paint_context);
 
 CoglFramebuffer * clutter_paint_context_get_base_framebuffer (ClutterPaintContext *paint_context);
+
+CLUTTER_EXPORT
+ClutterPaintFlag clutter_paint_context_get_paint_flags (ClutterPaintContext *paint_context);
 
 #endif /* CLUTTER_PAINT_CONTEXT_PRIVATE_H */

--- a/clutter/clutter/clutter-paint-context-private.h
+++ b/clutter/clutter/clutter-paint-context-private.h
@@ -23,6 +23,7 @@
 typedef enum _ClutterPaintFlag
 {
   CLUTTER_PAINT_FLAG_NONE = 0,
+  CLUTTER_PAINT_FLAG_NO_CURSORS = 1 << 0,
 } ClutterPaintFlag;
 
 ClutterPaintContext * clutter_paint_context_new_for_view (ClutterStageView     *view,

--- a/clutter/clutter/clutter-paint-context-private.h
+++ b/clutter/clutter/clutter-paint-context-private.h
@@ -24,6 +24,7 @@ typedef enum _ClutterPaintFlag
 {
   CLUTTER_PAINT_FLAG_NONE = 0,
   CLUTTER_PAINT_FLAG_NO_CURSORS = 1 << 0,
+  CLUTTER_PAINT_FLAG_NO_PAINT_SIGNAL = 1 << 0,
 } ClutterPaintFlag;
 
 ClutterPaintContext * clutter_paint_context_new_for_view (ClutterStageView     *view,

--- a/clutter/clutter/clutter-paint-context.c
+++ b/clutter/clutter/clutter-paint-context.c
@@ -66,7 +66,8 @@ clutter_paint_context_new_for_framebuffer (CoglFramebuffer *framebuffer)
 
   paint_context = g_new0 (ClutterPaintContext, 1);
   g_ref_count_init (&paint_context->ref_count);
-  paint_context->paint_flags = CLUTTER_PAINT_FLAG_NO_CURSORS;
+  paint_context->paint_flags = (CLUTTER_PAINT_FLAG_NO_CURSORS |
+                                CLUTTER_PAINT_FLAG_NO_PAINT_SIGNAL);
 
   clutter_paint_context_push_framebuffer (paint_context, framebuffer);
 

--- a/clutter/clutter/clutter-paint-context.c
+++ b/clutter/clutter/clutter-paint-context.c
@@ -23,6 +23,8 @@ struct _ClutterPaintContext
 {
   grefcount ref_count;
 
+  ClutterPaintFlag paint_flags;
+
   GList *framebuffers;
 
   ClutterStageView *view;
@@ -36,7 +38,8 @@ G_DEFINE_BOXED_TYPE (ClutterPaintContext, clutter_paint_context,
 
 ClutterPaintContext *
 clutter_paint_context_new_for_view (ClutterStageView     *view,
-                                    const cairo_region_t *redraw_clip)
+                                    const cairo_region_t *redraw_clip,
+                                    ClutterPaintFlag      paint_flags)
 {
   ClutterPaintContext *paint_context;
   CoglFramebuffer *framebuffer;
@@ -45,6 +48,7 @@ clutter_paint_context_new_for_view (ClutterStageView     *view,
   g_ref_count_init (&paint_context->ref_count);
   paint_context->view = view;
   paint_context->redraw_clip = cairo_region_copy (redraw_clip);
+  paint_context->paint_flags = paint_flags;
 
   framebuffer = clutter_stage_view_get_framebuffer (view);
   clutter_paint_context_push_framebuffer (paint_context, framebuffer);
@@ -62,6 +66,7 @@ clutter_paint_context_new_for_framebuffer (CoglFramebuffer *framebuffer)
 
   paint_context = g_new0 (ClutterPaintContext, 1);
   g_ref_count_init (&paint_context->ref_count);
+  paint_context->paint_flags = CLUTTER_PAINT_FLAG_NONE;
 
   clutter_paint_context_push_framebuffer (paint_context, framebuffer);
 
@@ -169,4 +174,13 @@ clutter_paint_context_is_drawing_off_stage (ClutterPaintContext *paint_context)
     return TRUE;
 
   return !paint_context->view;
+}
+
+/**
+ * clutter_paint_context_get_paint_flags: (skip)
+ */
+ClutterPaintFlag
+clutter_paint_context_get_paint_flags (ClutterPaintContext *paint_context)
+{
+  return paint_context->paint_flags;
 }

--- a/clutter/clutter/clutter-paint-context.c
+++ b/clutter/clutter/clutter-paint-context.c
@@ -66,7 +66,7 @@ clutter_paint_context_new_for_framebuffer (CoglFramebuffer *framebuffer)
 
   paint_context = g_new0 (ClutterPaintContext, 1);
   g_ref_count_init (&paint_context->ref_count);
-  paint_context->paint_flags = CLUTTER_PAINT_FLAG_NONE;
+  paint_context->paint_flags = CLUTTER_PAINT_FLAG_NO_CURSORS;
 
   clutter_paint_context_push_framebuffer (paint_context, framebuffer);
 

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -1320,14 +1320,8 @@ clutter_stage_queue_actor_relayout (ClutterStage *stage,
 {
   ClutterStagePrivate *priv = stage->priv;
 
-  if (g_hash_table_contains (priv->pending_relayouts, stage))
-    return;
-
   if (g_hash_table_size (priv->pending_relayouts) == 0)
     _clutter_stage_schedule_update (stage);
-
-  if (actor == (ClutterActor *) stage)
-    g_hash_table_remove_all (priv->pending_relayouts);
 
   g_hash_table_add (priv->pending_relayouts, g_object_ref (actor));
   priv->pending_relayouts_version++;

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -934,7 +934,8 @@ clutter_stage_do_paint_view (ClutterStage         *stage,
   ClutterPaintContext *paint_context;
   cairo_rectangle_int_t clip_rect;
 
-  paint_context = clutter_paint_context_new_for_view (view, redraw_clip);
+  paint_context = clutter_paint_context_new_for_view (view, redraw_clip,
+                                                      CLUTTER_PAINT_FLAG_NONE);
 
   cairo_region_get_extents (redraw_clip, &clip_rect);
   setup_view_for_pick_or_paint (stage, view, &clip_rect);

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -4458,6 +4458,100 @@ clutter_stage_get_capture_final_size (ClutterStage          *stage,
   return TRUE;
 }
 
+/**
+ * clutter_stage_paint_to_framebuffer: (skip)
+ */
+void
+clutter_stage_paint_to_framebuffer (ClutterStage                *stage,
+                                    CoglFramebuffer             *framebuffer,
+                                    const cairo_rectangle_int_t *rect,
+                                    float                        scale,
+                                    ClutterPaintFlag             paint_flags)
+{
+  ClutterStagePrivate *priv = stage->priv;
+  ClutterPaintContext *paint_context;
+  cairo_region_t *redraw_clip;
+
+  redraw_clip = cairo_region_create_rectangle (rect);
+  paint_context = clutter_paint_context_new_for_framebuffer (framebuffer);
+  cairo_region_destroy (redraw_clip);
+
+  cogl_framebuffer_push_matrix (framebuffer);
+  cogl_framebuffer_set_projection_matrix (framebuffer, &priv->projection);
+  cogl_framebuffer_set_viewport (framebuffer,
+                                 -(rect->x * scale),
+                                 -(rect->y * scale),
+                                 priv->viewport[2] * scale,
+                                 priv->viewport[3] * scale);
+  clutter_actor_paint (CLUTTER_ACTOR (stage), paint_context);
+  cogl_framebuffer_pop_matrix (framebuffer);
+
+  clutter_paint_context_destroy (paint_context);
+}
+
+/**
+ * clutter_stage_paint_to_buffer: (skip)
+ */
+gboolean
+clutter_stage_paint_to_buffer (ClutterStage                 *stage,
+                               const cairo_rectangle_int_t  *rect,
+                               float                         scale,
+                               uint8_t                      *data,
+                               int                           stride,
+                               CoglPixelFormat               format,
+                               ClutterPaintFlag              paint_flags,
+                               GError                      **error)
+{
+  ClutterBackend *clutter_backend = clutter_get_default_backend ();
+  CoglContext *cogl_context =
+    clutter_backend_get_cogl_context (clutter_backend);
+  int texture_width, texture_height;
+  CoglTexture2D *texture;
+  CoglOffscreen *offscreen;
+  CoglFramebuffer *framebuffer;
+  CoglBitmap *bitmap;
+
+  texture_width = (int) ceilf (rect->width * scale);
+  texture_height = (int) ceilf (rect->height * scale);
+  texture = cogl_texture_2d_new_with_size (cogl_context,
+                                           texture_width,
+                                           texture_height);
+  if (!texture)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to create %dx%d texture",
+                   texture_width, texture_height);
+      return FALSE;
+    }
+
+  offscreen = cogl_offscreen_new_with_texture (COGL_TEXTURE (texture));
+  framebuffer = COGL_FRAMEBUFFER (offscreen);
+
+  cogl_object_unref (texture);
+
+  if (!cogl_framebuffer_allocate (framebuffer, error))
+    return FALSE;
+
+  clutter_stage_paint_to_framebuffer (stage, framebuffer,
+                                      rect, scale, paint_flags);
+
+  bitmap = cogl_bitmap_new_for_data (cogl_context,
+                                     texture_width, texture_height,
+                                     format,
+                                     stride,
+                                     data);
+
+  cogl_framebuffer_read_pixels_into_bitmap (framebuffer,
+                                            0, 0,
+                                            COGL_READ_PIXELS_COLOR_BUFFER,
+                                            bitmap);
+
+  cogl_object_unref (bitmap);
+  cogl_object_unref (framebuffer);
+
+  return TRUE;
+}
+
 static void
 capture_view_into (ClutterStage          *stage,
                    gboolean               paint,

--- a/clutter/clutter/clutter-stage.c
+++ b/clutter/clutter/clutter-stage.c
@@ -4560,50 +4560,17 @@ capture_view_into (ClutterStage          *stage,
                    uint8_t               *data,
                    int                    stride)
 {
-  CoglFramebuffer *framebuffer;
-  ClutterBackend *backend;
-  CoglContext *context;
-  CoglBitmap *bitmap;
-  cairo_rectangle_int_t view_layout;
+  g_autoptr (GError) error = NULL;
   float view_scale;
-  float texture_width;
-  float texture_height;
 
   g_return_if_fail (CLUTTER_IS_STAGE (stage));
 
-  framebuffer = clutter_stage_view_get_framebuffer (view);
-
-  if (paint)
-    {
-      cairo_region_t *region;
-
-      _clutter_stage_maybe_setup_viewport (stage, view);
-      region = cairo_region_create_rectangle (rect);
-      clutter_stage_do_paint_view (stage, view, region);
-      cairo_region_destroy (region);
-    }
-
   view_scale = clutter_stage_view_get_scale (view);
-  texture_width = roundf (rect->width * view_scale);
-  texture_height = roundf (rect->height * view_scale);
-
-  backend = clutter_get_default_backend ();
-  context = clutter_backend_get_cogl_context (backend);
-  bitmap = cogl_bitmap_new_for_data (context,
-                                     texture_width, texture_height,
-                                     CLUTTER_CAIRO_FORMAT_ARGB32,
-                                     stride,
-                                     data);
-
-  clutter_stage_view_get_layout (view, &view_layout);
-
-  cogl_framebuffer_read_pixels_into_bitmap (framebuffer,
-                                            roundf ((rect->x - view_layout.x) * view_scale),
-                                            roundf ((rect->y - view_layout.y) * view_scale),
-                                            COGL_READ_PIXELS_COLOR_BUFFER,
-                                            bitmap);
-
-  cogl_object_unref (bitmap);
+  if (!clutter_stage_paint_to_buffer (stage, rect, view_scale, data, stride,
+                                      CLUTTER_CAIRO_FORMAT_ARGB32,
+                                      CLUTTER_PAINT_FLAG_NO_CURSORS,
+                                      &error))
+    g_warning ("Failed to capture stage: %s", error->message);
 }
 
 void

--- a/clutter/clutter/cogl/clutter-stage-cogl.c
+++ b/clutter/clutter/cogl/clutter-stage-cogl.c
@@ -375,14 +375,10 @@ static gboolean
 swap_framebuffer (ClutterStageWindow *stage_window,
                   ClutterStageView   *view,
                   cairo_region_t     *swap_region,
-                  gboolean            swap_with_damage,
-                  cairo_region_t     *queued_redraw_clip)
+                  gboolean            swap_with_damage)
 {
   CoglFramebuffer *framebuffer = clutter_stage_view_get_onscreen (view);
   int *damage, n_rects, i;
-
-  if (G_UNLIKELY ((clutter_paint_debug_flags & CLUTTER_DEBUG_PAINT_DAMAGE_REGION)))
-    paint_damage_region (stage_window, view, swap_region, queued_redraw_clip);
 
   n_rects = cairo_region_num_rectangles (swap_region);
   damage = g_newa (int, n_rects * 4);
@@ -620,7 +616,7 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
   gboolean swap_with_damage;
   ClutterActor *wrapper;
   cairo_region_t *redraw_clip;
-  cairo_region_t *queued_redraw_clip;
+  cairo_region_t *queued_redraw_clip = NULL;
   cairo_region_t *fb_clip_region;
   cairo_region_t *swap_region;
   cairo_rectangle_int_t redraw_rect;
@@ -643,6 +639,8 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
   has_buffer_age = cogl_is_onscreen (fb) && is_buffer_age_enabled ();
 
   redraw_clip = clutter_stage_view_take_redraw_clip (view);
+  if (G_UNLIKELY (clutter_paint_debug_flags & CLUTTER_DEBUG_PAINT_DAMAGE_REGION))
+    queued_redraw_clip = cairo_region_copy (redraw_clip);
 
   /* NB: a NULL redraw clip == full stage redraw */
   if (!redraw_clip)
@@ -699,8 +697,6 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
       g_clear_pointer (&redraw_clip, cairo_region_destroy);
       redraw_clip = cairo_region_create_rectangle (&view_rect);
     }
-
-  queued_redraw_clip = cairo_region_copy (redraw_clip);
 
   if (may_use_clipped_redraw &&
       G_LIKELY (!(clutter_paint_debug_flags & CLUTTER_DEBUG_DISABLE_CLIPPED_REDRAWS)))
@@ -932,7 +928,6 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
     }
 
   g_clear_pointer (&redraw_clip, cairo_region_destroy);
-  g_clear_pointer (&queued_redraw_clip, cairo_region_destroy);
   g_clear_pointer (&fb_clip_region, cairo_region_destroy);
 
   if (do_swap_buffer)
@@ -953,11 +948,17 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
           swap_region = transformed_swap_region;
         }
 
+      if (queued_redraw_clip)
+        {
+          paint_damage_region (stage_window, view,
+                               swap_region, queued_redraw_clip);
+          cairo_region_destroy (queued_redraw_clip);
+        }
+
       res = swap_framebuffer (stage_window,
                               view,
                               swap_region,
-                              swap_with_damage,
-                              queued_redraw_clip);
+                              swap_with_damage);
 
       cairo_region_destroy (swap_region);
 
@@ -965,6 +966,7 @@ clutter_stage_cogl_redraw_view (ClutterStageWindow *stage_window,
     }
   else
     {
+      g_clear_pointer (&queued_redraw_clip, cairo_region_destroy);
       return FALSE;
     }
 }

--- a/src/backends/meta-input-settings.c
+++ b/src/backends/meta-input-settings.c
@@ -818,7 +818,7 @@ update_trackball_scroll_button (MetaInputSettings  *input_settings,
 
       for (l = devices; l; l = l->next)
         {
-          device = devices->data;
+          device = l->data;
 
           if (input_settings_class->is_trackball_device (input_settings, device))
             input_settings_class->set_scroll_button (input_settings, device, button);

--- a/src/backends/meta-screen-cast-monitor-stream-src.c
+++ b/src/backends/meta-screen-cast-monitor-stream-src.c
@@ -115,9 +115,10 @@ meta_screen_cast_monitor_stream_src_get_specs (MetaScreenCastStreamSrc *src,
 }
 
 static void
-stage_painted (MetaStage        *stage,
-               ClutterStageView *view,
-               gpointer          user_data)
+stage_painted (MetaStage           *stage,
+               ClutterStageView    *view,
+               ClutterPaintContext *paint_context,
+               gpointer             user_data)
 {
   MetaScreenCastStreamSrc *src = META_SCREEN_CAST_STREAM_SRC (user_data);
 

--- a/src/backends/meta-stage-private.h
+++ b/src/backends/meta-stage-private.h
@@ -38,9 +38,10 @@ typedef enum
   META_STAGE_WATCH_AFTER_PAINT,
 } MetaStageWatchPhase;
 
-typedef void (* MetaStageWatchFunc) (MetaStage        *stage,
-                                     ClutterStageView *view,
-                                     gpointer          user_data);
+typedef void (* MetaStageWatchFunc) (MetaStage           *stage,
+                                     ClutterStageView    *view,
+                                     ClutterPaintContext *paint_context,
+                                     gpointer             user_data);
 
 ClutterActor     *meta_stage_new                     (MetaBackend *backend);
 

--- a/src/backends/meta-stage.c
+++ b/src/backends/meta-stage.c
@@ -198,17 +198,22 @@ meta_stage_paint (ClutterActor        *actor,
   CLUTTER_ACTOR_CLASS (meta_stage_parent_class)->paint (actor, paint_context);
 
   view = clutter_paint_context_get_stage_view (paint_context);
-
-  notify_watchers_for_mode (stage, view, paint_context,
-                            META_STAGE_WATCH_AFTER_ACTOR_PAINT);
+  if (view)
+    {
+      notify_watchers_for_mode (stage, view, paint_context,
+                                META_STAGE_WATCH_AFTER_ACTOR_PAINT);
+    }
 
   g_signal_emit (stage, signals[ACTORS_PAINTED], 0);
 
   for (l = stage->overlays; l; l = l->next)
     meta_overlay_paint (l->data, paint_context);
 
-  notify_watchers_for_mode (stage, view, paint_context,
-                            META_STAGE_WATCH_AFTER_OVERLAY_PAINT);
+  if (view)
+    {
+      notify_watchers_for_mode (stage, view, paint_context,
+                                META_STAGE_WATCH_AFTER_OVERLAY_PAINT);
+    }
 }
 
 static void

--- a/src/backends/meta-stage.c
+++ b/src/backends/meta-stage.c
@@ -206,8 +206,12 @@ meta_stage_paint (ClutterActor        *actor,
 
   g_signal_emit (stage, signals[ACTORS_PAINTED], 0);
 
-  for (l = stage->overlays; l; l = l->next)
-    meta_overlay_paint (l->data, paint_context);
+  if (!(clutter_paint_context_get_paint_flags (paint_context) &
+        CLUTTER_PAINT_FLAG_NO_CURSORS))
+    {
+      for (l = stage->overlays; l; l = l->next)
+        meta_overlay_paint (l->data, paint_context);
+    }
 
   if (view)
     {

--- a/src/backends/meta-stage.c
+++ b/src/backends/meta-stage.c
@@ -204,7 +204,9 @@ meta_stage_paint (ClutterActor        *actor,
                                 META_STAGE_WATCH_AFTER_ACTOR_PAINT);
     }
 
-  g_signal_emit (stage, signals[ACTORS_PAINTED], 0);
+  if (!(clutter_paint_context_get_paint_flags (paint_context) &
+        CLUTTER_PAINT_FLAG_NO_PAINT_SIGNAL))
+    g_signal_emit (stage, signals[ACTORS_PAINTED], 0);
 
   if (!(clutter_paint_context_get_paint_flags (paint_context) &
         CLUTTER_PAINT_FLAG_NO_CURSORS))

--- a/src/backends/x11/meta-backend-x11.c
+++ b/src/backends/x11/meta-backend-x11.c
@@ -855,6 +855,7 @@ meta_backend_x11_class_init (MetaBackendX11Class *klass)
 static void
 meta_backend_x11_init (MetaBackendX11 *x11)
 {
+  XInitThreads ();
 }
 
 Display *

--- a/src/backends/x11/meta-stage-x11.c
+++ b/src/backends/x11/meta-stage-x11.c
@@ -845,12 +845,16 @@ meta_stage_x11_translate_event (MetaStageX11 *stage_x11,
       g_debug ("Client message for stage, win:0x%x",
                (unsigned int) xevent->xany.window);
 
-      if (handle_wm_protocols_event (backend_x11, stage_x11, xevent))
+      if (xevent->xclient.message_type == backend_x11->atom_WM_PROTOCOLS)
         {
-          event->any.type = CLUTTER_DELETE;
-          event->any.stage = stage;
-          res = TRUE;
+          if (handle_wm_protocols_event (backend_x11, stage_x11, xevent))
+            {
+              event->any.type = CLUTTER_DELETE;
+              event->any.stage = stage;
+              res = TRUE;
+            }
         }
+
       break;
 
     default:

--- a/src/compositor/meta-shaped-texture-private.h
+++ b/src/compositor/meta-shaped-texture-private.h
@@ -66,4 +66,7 @@ gboolean meta_shaped_texture_update_area (MetaShapedTexture     *stex,
 int meta_shaped_texture_get_width (MetaShapedTexture *stex);
 int meta_shaped_texture_get_height (MetaShapedTexture *stex);
 
+void meta_shaped_texture_set_clip_region (MetaShapedTexture *stex,
+                                          cairo_region_t    *clip_region);
+
 #endif

--- a/src/compositor/meta-shaped-texture.c
+++ b/src/compositor/meta-shaped-texture.c
@@ -87,6 +87,9 @@ struct _MetaShapedTexture
   /* The region containing only fully opaque pixels */
   cairo_region_t *opaque_region;
 
+  /* MetaCullable regions, see that documentation for more details */
+  cairo_region_t *clip_region;
+
   gboolean size_invalid;
   MetaMonitorTransform transform;
   gboolean has_viewport_src_rect;
@@ -214,6 +217,15 @@ ensure_size_valid (MetaShapedTexture *stex)
     update_size (stex);
 }
 
+void
+meta_shaped_texture_set_clip_region (MetaShapedTexture *stex,
+                                     cairo_region_t    *clip_region)
+{
+  g_clear_pointer (&stex->clip_region, cairo_region_destroy);
+  if (clip_region)
+    stex->clip_region = cairo_region_reference (clip_region);
+}
+
 static void
 meta_shaped_texture_reset_pipelines (MetaShapedTexture *stex)
 {
@@ -239,6 +251,7 @@ meta_shaped_texture_dispose (GObject *object)
   meta_shaped_texture_reset_pipelines (stex);
 
   g_clear_pointer (&stex->opaque_region, cairo_region_destroy);
+  g_clear_pointer (&stex->clip_region, cairo_region_destroy);
 
   g_clear_pointer (&stex->snippet, cogl_object_unref);
 
@@ -585,12 +598,19 @@ do_paint_content (MetaShapedTexture   *stex,
 
   if (use_opaque_region)
     {
-      blended_tex_region = cairo_region_create_rectangle (&content_rect);
+      if (stex->clip_region)
+        blended_tex_region = cairo_region_copy (stex->clip_region);
+      else
+        blended_tex_region = cairo_region_create_rectangle (&content_rect);
+
       cairo_region_subtract (blended_tex_region, stex->opaque_region);
     }
   else
     {
-      blended_tex_region = NULL;
+      if (stex->clip_region)
+        blended_tex_region = cairo_region_reference (stex->clip_region);
+      else
+        blended_tex_region = NULL;
     }
 
   /* Limit to how many separate rectangles we'll draw; beyond this just
@@ -612,10 +632,21 @@ do_paint_content (MetaShapedTexture   *stex,
   /* First, paint the unblended parts, which are part of the opaque region. */
   if (use_opaque_region)
     {
+      cairo_region_t *region;
       int n_rects;
       int i;
 
-      if (!cairo_region_is_empty (stex->opaque_region))
+      if (stex->clip_region)
+        {
+          region = cairo_region_copy (stex->clip_region);
+          cairo_region_intersect (region, stex->opaque_region);
+        }
+      else
+        {
+          region = cairo_region_reference (stex->opaque_region);
+        }
+
+      if (!cairo_region_is_empty (region))
         {
           CoglPipeline *opaque_pipeline;
 
@@ -623,16 +654,18 @@ do_paint_content (MetaShapedTexture   *stex,
           cogl_pipeline_set_layer_texture (opaque_pipeline, 0, paint_tex);
           cogl_pipeline_set_layer_filters (opaque_pipeline, 0, filter, filter);
 
-          n_rects = cairo_region_num_rectangles (stex->opaque_region);
+          n_rects = cairo_region_num_rectangles (region);
           for (i = 0; i < n_rects; i++)
             {
               cairo_rectangle_int_t rect;
-              cairo_region_get_rectangle (stex->opaque_region, i, &rect);
+              cairo_region_get_rectangle (region, i, &rect);
               paint_clipped_rectangle_node (stex, root_node,
                                             opaque_pipeline,
                                             &rect, alloc);
             }
         }
+
+      cairo_region_destroy (region);
     }
 
   /* Now, go ahead and paint the blended parts. */
@@ -756,6 +789,9 @@ meta_shaped_texture_paint_content (ClutterContent      *content,
   ClutterActorBox alloc;
   CoglTexture *paint_tex = NULL;
   uint8_t opacity;
+
+  if (stex->clip_region && cairo_region_is_empty (stex->clip_region))
+    return;
 
   /* The GL EXT_texture_from_pixmap extension does allow for it to be
    * used together with SGIS_generate_mipmap, however this is very

--- a/src/compositor/meta-window-actor-x11.c
+++ b/src/compositor/meta-window-actor-x11.c
@@ -1630,8 +1630,8 @@ meta_window_actor_x11_init (MetaWindowActorX11 *self)
 
   self->shadow_factory = meta_shadow_factory_get_default ();
   self->shadow_factory_changed_handler_id =
-    g_signal_connect (self->shadow_factory,
-                      "changed",
-                      G_CALLBACK (invalidate_shadow),
-                      self);
+    g_signal_connect_swapped (self->shadow_factory,
+                              "changed",
+                              G_CALLBACK (invalidate_shadow),
+                              self);
 }

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2129,7 +2129,7 @@ process_special_modifier_key (MetaDisplay          *display,
       return TRUE;
     }
   else if (event->type == CLUTTER_KEY_PRESS &&
-           (event->modifier_state & ~(IGNORED_MODIFIERS)) == 0 &&
+           ((event->modifier_state & ~(IGNORED_MODIFIERS)) & CLUTTER_MODIFIER_MASK) == 0 &&
            resolved_key_combo_has_keycode (resolved_key_combo,
                                            event->hardware_keycode))
     {

--- a/src/core/meta-selection-private.h
+++ b/src/core/meta-selection-private.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Red Hat
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Carlos Garnacho <carlosg@gnome.org>
+ */
+
+#ifndef META_SELECTION_PRIVATE_H
+#define META_SELECTION_PRIVATE_H
+
+#include "meta/meta-selection.h"
+
+MetaSelectionSource *
+  meta_selection_get_current_owner (MetaSelection     *selection,
+                                    MetaSelectionType  selection_type);
+
+#endif /* META_SELECTION_PRIVATE_H */

--- a/src/core/meta-selection.c
+++ b/src/core/meta-selection.c
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include "core/meta-selection-private.h"
 #include "meta/meta-selection.h"
 
 typedef struct TransferRequest TransferRequest;
@@ -401,4 +402,14 @@ meta_selection_transfer_finish (MetaSelection  *selection,
                         meta_selection_transfer_async, FALSE);
 
   return g_task_propagate_boolean (G_TASK (result), error);
+}
+
+MetaSelectionSource *
+meta_selection_get_current_owner (MetaSelection     *selection,
+                                  MetaSelectionType  selection_type)
+{
+  g_return_val_if_fail (META_IS_SELECTION (selection), NULL);
+  g_return_val_if_fail (selection_type < META_N_SELECTION_TYPES, NULL);
+
+  return selection->owners[selection_type];
 }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3770,6 +3770,8 @@ meta_window_activate_full (MetaWindow     *window,
     meta_window_focus (window, timestamp);
   else
     meta_workspace_activate_with_focus (window->workspace, window, timestamp);
+
+  meta_window_check_alive (window, timestamp);
 }
 
 /* This function exists since most of the functionality in window_activate
@@ -4808,8 +4810,6 @@ meta_window_focus (MetaWindow  *window,
                   window->desc);
       return;
     }
-
-  meta_window_check_alive (window, timestamp);
 
   META_WINDOW_GET_CLASS (window)->focus (window, timestamp);
 
@@ -8417,6 +8417,7 @@ meta_window_handle_ungrabbed_event (MetaWindow         *window,
                   "Focusing %s due to button %u press (display.c)\n",
                   window->desc, button);
       meta_window_focus (window, event->any.time);
+      meta_window_check_alive (window, event->any.time);
     }
   else
     /* However, do allow terminals to lose focus due to new

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -277,7 +277,7 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
                                error_str);
       g_clear_object (&priv->pending_task);
     }
-  else if (priv->pending_task)
+  else if (priv->pending_task && priv->data->len == 0 && !priv->delete_pending)
     {
       size_t result;
 

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -199,6 +199,7 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
     meta_x11_selection_output_stream_get_instance_private (stream);
   Display *xdisplay;
   size_t element_size, n_elements;
+  gboolean first_chunk = FALSE;
   int error_code;
 
   g_assert (!priv->delete_pending);
@@ -212,6 +213,9 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
 
   element_size = get_element_size (priv->format);
   n_elements = priv->data->len / element_size;
+
+  if (!priv->incr)
+    first_chunk = TRUE;
 
   if (!g_output_stream_is_closing (G_OUTPUT_STREAM (stream)))
     {
@@ -248,7 +252,8 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
       g_byte_array_remove_range (priv->data, 0, n_elements * element_size);
     }
 
-  meta_x11_selection_output_stream_notify_selection (stream);
+  if (first_chunk)
+    meta_x11_selection_output_stream_notify_selection (stream);
 
   priv->delete_pending = TRUE;
   g_cond_broadcast (&priv->cond);

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -243,9 +243,13 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
                        PropModeReplace,
                        (guchar *) &(long) { n_elements },
                        1);
+      priv->delete_pending = TRUE;
     }
   else
     {
+      if (priv->incr && priv->data->len > 0)
+        priv->delete_pending = TRUE;
+
       XChangeProperty (xdisplay,
                        priv->xwindow,
                        priv->xproperty,
@@ -260,7 +264,6 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
   if (first_chunk)
     meta_x11_selection_output_stream_notify_selection (stream);
 
-  priv->delete_pending = TRUE;
   g_cond_broadcast (&priv->cond);
   g_mutex_unlock (&priv->mutex);
 

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -384,16 +384,11 @@ meta_x11_selection_output_stream_write_async (GOutputStream       *output_stream
       g_object_unref (task);
       return;
     }
-  else if (!meta_x11_selection_output_stream_can_flush (stream))
-    {
-      g_assert (priv->pending_task == NULL);
-      priv->pending_task = task;
-      g_task_set_task_data (task, GSIZE_TO_POINTER (count), NULL);
-      return;
-    }
   else
     {
-      meta_x11_selection_output_stream_perform_flush (stream);
+      if (meta_x11_selection_output_stream_can_flush (stream))
+        meta_x11_selection_output_stream_perform_flush (stream);
+
       g_task_return_int (task, count);
       g_object_unref (task);
       return;

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -110,7 +110,7 @@ get_max_request_size (MetaX11Display *display)
   if (size <= 0)
     size = XMaxRequestSize (display->xdisplay);
 
-  return size - 100;
+  return (size - 100) * 4;
 }
 
 static gboolean

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -282,13 +282,16 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
       priv->delete_pending = FALSE;
       priv->pipe_error = TRUE;
 
-      XGetErrorText (xdisplay, error_code, error_str, sizeof (error_str));
-      g_task_return_new_error (priv->pending_task,
-                               G_IO_ERROR,
-                               G_IO_ERROR_BROKEN_PIPE,
-                               "Failed to flush selection output stream: %s",
-                               error_str);
-      g_clear_object (&priv->pending_task);
+      if (priv->pending_task)
+        {
+          XGetErrorText (xdisplay, error_code, error_str, sizeof (error_str));
+          g_task_return_new_error (priv->pending_task,
+                                   G_IO_ERROR,
+                                   G_IO_ERROR_BROKEN_PIPE,
+                                   "Failed to flush selection output stream: %s",
+                                   error_str);
+          g_clear_object (&priv->pending_task);
+        }
     }
   else if (priv->pending_task && priv->data->len == 0 && !priv->delete_pending)
     {

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -223,7 +223,7 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
   if (!priv->incr)
     first_chunk = TRUE;
 
-  if (!g_output_stream_is_closing (G_OUTPUT_STREAM (stream)))
+  if (!priv->incr && priv->data->len > max_size)
     {
       XWindowAttributes attrs;
 

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -125,7 +125,12 @@ meta_x11_selection_output_stream_needs_flush_unlocked (MetaX11SelectionOutputStr
     meta_x11_selection_output_stream_get_instance_private (stream);
 
   if (priv->data->len == 0)
-    return FALSE;
+    {
+      if (priv->incr)
+        return g_output_stream_is_closing (G_OUTPUT_STREAM (stream));
+      else
+        return FALSE;
+    }
 
   if (g_output_stream_is_closing (G_OUTPUT_STREAM (stream)))
     return TRUE;

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -229,7 +229,7 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
       XChangeProperty (xdisplay,
                        priv->xwindow,
                        priv->xproperty,
-                       XInternAtom (priv->x11_display->xdisplay, "INCR", True),
+                       XInternAtom (priv->x11_display->xdisplay, "INCR", False),
                        32,
                        PropModeReplace,
                        (guchar *) &(long) { n_elements },

--- a/src/x11/meta-x11-selection-output-stream.c
+++ b/src/x11/meta-x11-selection-output-stream.c
@@ -60,6 +60,8 @@ G_DEFINE_TYPE_WITH_PRIVATE (MetaX11SelectionOutputStream,
                             meta_x11_selection_output_stream,
                             G_TYPE_OUTPUT_STREAM);
 
+static size_t get_element_size (int format);
+
 static void
 meta_x11_selection_output_stream_notify_selection (MetaX11SelectionOutputStream *stream)
 {
@@ -96,6 +98,9 @@ meta_x11_selection_output_stream_can_flush (MetaX11SelectionOutputStream *stream
     meta_x11_selection_output_stream_get_instance_private (stream);
 
   if (priv->delete_pending)
+    return FALSE;
+  if (!g_output_stream_is_closing (G_OUTPUT_STREAM (stream)) &&
+      priv->data->len < get_element_size (priv->format))
     return FALSE;
 
   return TRUE;
@@ -241,7 +246,7 @@ meta_x11_selection_output_stream_perform_flush (MetaX11SelectionOutputStream *st
                        priv->data->data,
                        n_elements);
       g_byte_array_remove_range (priv->data, 0, n_elements * element_size);
-      if (priv->data->len < element_size)
+      if (priv->data->len == 0)
         priv->flush_requested = FALSE;
     }
 
@@ -391,7 +396,7 @@ meta_x11_selection_output_request_flush (MetaX11SelectionOutputStream *stream)
 
   g_mutex_lock (&priv->mutex);
 
-  if (priv->data->len >= get_element_size (priv->format))
+  if (priv->data->len > 0)
     priv->flush_requested = TRUE;
 
   needs_flush = meta_x11_selection_output_stream_needs_flush_unlocked (stream);

--- a/src/x11/meta-x11-selection.c
+++ b/src/x11/meta-x11-selection.c
@@ -297,8 +297,8 @@ source_new_cb (GObject      *object,
   source = meta_selection_source_x11_new_finish (res, &error);
   if (source)
     {
-      meta_selection_set_owner (selection, selection_type, source);
       g_set_object (&x11_display->selection.owners[selection_type], source);
+      meta_selection_set_owner (selection, selection_type, source);
       g_object_unref (source);
     }
   else if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
@@ -382,7 +382,7 @@ notify_selection_owner (MetaX11Display      *x11_display,
 {
   Display *xdisplay = x11_display->xdisplay;
 
-  if (new_owner && !META_IS_SELECTION_SOURCE_X11 (new_owner))
+  if (new_owner && new_owner != x11_display->selection.owners[selection_type])
     {
       if (x11_display->selection.cancellables[selection_type])
         {

--- a/src/x11/meta-x11-selection.c
+++ b/src/x11/meta-x11-selection.c
@@ -339,6 +339,7 @@ meta_x11_selection_handle_xfixes_selection_notify (MetaX11Display *x11_display,
           /* An X client went away, clear the selection */
           meta_selection_unset_owner (selection, selection_type,
                                       x11_display->selection.owners[selection_type]);
+          g_clear_object (&x11_display->selection.owners[selection_type]);
         }
     }
   else if (event->owner != x11_display->selection.xwindow)

--- a/src/x11/meta-x11-selection.c
+++ b/src/x11/meta-x11-selection.c
@@ -24,12 +24,20 @@
 #include <gdk/gdkx.h>
 
 #include "core/meta-selection-private.h"
+#include "meta/meta-selection-source-memory.h"
 #include "x11/meta-selection-source-x11-private.h"
 #include "x11/meta-x11-selection-output-stream-private.h"
 #include "x11/meta-x11-selection-private.h"
 
 #define UTF8_STRING_MIMETYPE "text/plain;charset=utf-8"
 #define STRING_MIMETYPE "text/plain"
+
+/* Set an arbitrary (although generous) threshold to determine whether a
+ * XFixesSelectionNotify corresponds to a XSetSelectionOwner from another
+ * client. The selection timestamp is not updated if the owner client is
+ * closed.
+ */
+#define SELECTION_CLEARED_BY_CLIENT(e) (e->timestamp - e->selection_timestamp < 50)
 
 static gboolean
 atom_to_selection_type (Display           *xdisplay,
@@ -332,9 +340,19 @@ meta_x11_selection_handle_xfixes_selection_notify (MetaX11Display *x11_display,
 
   x11_display->selection.cancellables[selection_type] = g_cancellable_new ();
 
-  if (event->owner == None)
+  if (event->owner == None && x11_display->selection.owners[selection_type])
     {
-      if (x11_display->selection.owners[selection_type])
+      if (SELECTION_CLEARED_BY_CLIENT (event))
+        {
+          MetaSelectionSource *source;
+
+          /* Replace with an empty owner */
+          source = g_object_new (META_TYPE_SELECTION_SOURCE_MEMORY, NULL);
+          g_set_object (&x11_display->selection.owners[selection_type], source);
+          meta_selection_set_owner (selection, selection_type, source);
+          g_object_unref (source);
+        }
+      else
         {
           /* An X client went away, clear the selection */
           meta_selection_unset_owner (selection, selection_type,
@@ -342,7 +360,7 @@ meta_x11_selection_handle_xfixes_selection_notify (MetaX11Display *x11_display,
           g_clear_object (&x11_display->selection.owners[selection_type]);
         }
     }
-  else if (event->owner != x11_display->selection.xwindow)
+  else if (event->owner != None && event->owner != x11_display->selection.xwindow)
     {
       SourceNewData *data;
 


### PR DESCRIPTION
A selection of cherry-picks for mutter 3.36. All of them applied cleanly and no regressions were spotted.

I left out all Wayland-related cherry-picks for now, for the sake of reducing the number of cherry-picks.

https://phabricator.endlessm.com/T30428