### PR TITLE
monitor-manager: Set switch config when create monitors config

### DIFF
--- a/src/backends/meta-monitor-config-manager.c
+++ b/src/backends/meta-monitor-config-manager.c
@@ -747,6 +747,7 @@ meta_monitor_config_manager_create_linear (MetaMonitorConfigManager *config_mana
   int x;
   GList *monitors;
   GList *l;
+  MetaMonitorsConfig *monitors_config;
 
   primary_monitor = find_primary_monitor (monitor_manager);
   if (!primary_monitor)
@@ -790,10 +791,15 @@ meta_monitor_config_manager_create_linear (MetaMonitorConfigManager *config_mana
       x += logical_monitor_config->layout.width;
     }
 
-  return meta_monitors_config_new (monitor_manager,
-                                   logical_monitor_configs,
-                                   layout_mode,
-                                   META_MONITORS_CONFIG_FLAG_NONE);
+  monitors_config = meta_monitors_config_new (monitor_manager,
+                                              logical_monitor_configs,
+                                              layout_mode,
+                                              META_MONITORS_CONFIG_FLAG_NONE);
+
+  if (monitors_config)
+    meta_monitors_config_set_switch_config (monitors_config, META_MONITOR_SWITCH_CONFIG_ALL_LINEAR);
+
+  return monitors_config;
 }
 
 MetaMonitorsConfig *
@@ -1075,6 +1081,7 @@ create_for_switch_config_all_mirror (MetaMonitorConfigManager *config_manager)
   GList *modes;
   GList *monitors;
   GList *l;
+  MetaMonitorsConfig *monitors_config;
 
   monitors = meta_monitor_manager_get_monitors (monitor_manager);
   monitor = monitors->data;
@@ -1167,10 +1174,15 @@ create_for_switch_config_all_mirror (MetaMonitorConfigManager *config_manager)
 
   logical_monitor_configs = g_list_append (NULL, logical_monitor_config);
   layout_mode = meta_monitor_manager_get_default_layout_mode (monitor_manager);
-  return meta_monitors_config_new (monitor_manager,
-                                   logical_monitor_configs,
-                                   layout_mode,
-                                   META_MONITORS_CONFIG_FLAG_NONE);
+  monitors_config = meta_monitors_config_new (monitor_manager,
+                                              logical_monitor_configs,
+                                              layout_mode,
+                                              META_MONITORS_CONFIG_FLAG_NONE);
+
+  if (monitors_config)
+    meta_monitors_config_set_switch_config (monitors_config, META_MONITOR_SWITCH_CONFIG_ALL_MIRROR);
+
+  return monitors_config;
 }
 
 static MetaMonitorsConfig *
@@ -1182,6 +1194,7 @@ create_for_switch_config_external (MetaMonitorConfigManager *config_manager)
   MetaLogicalMonitorLayoutMode layout_mode;
   GList *monitors;
   GList *l;
+  MetaMonitorsConfig *monitors_config;
 
   layout_mode = meta_monitor_manager_get_default_layout_mode (monitor_manager);
 
@@ -1209,10 +1222,15 @@ create_for_switch_config_external (MetaMonitorConfigManager *config_manager)
       x += logical_monitor_config->layout.width;
     }
 
-  return meta_monitors_config_new (monitor_manager,
-                                   logical_monitor_configs,
-                                   layout_mode,
-                                   META_MONITORS_CONFIG_FLAG_NONE);
+  monitors_config = meta_monitors_config_new (monitor_manager,
+                                              logical_monitor_configs,
+                                              layout_mode,
+                                              META_MONITORS_CONFIG_FLAG_NONE);
+
+  if (monitors_config)
+    meta_monitors_config_set_switch_config (monitors_config, META_MONITOR_SWITCH_CONFIG_EXTERNAL);
+
+  return monitors_config;
 }
 
 static MetaMonitorsConfig *
@@ -1223,6 +1241,7 @@ create_for_switch_config_builtin (MetaMonitorConfigManager *config_manager)
   GList *logical_monitor_configs;
   MetaLogicalMonitorConfig *primary_logical_monitor_config;
   MetaMonitor *monitor;
+  MetaMonitorsConfig *monitors_config;
 
   monitor = meta_monitor_manager_get_laptop_panel (monitor_manager);
   if (!monitor)
@@ -1240,10 +1259,15 @@ create_for_switch_config_builtin (MetaMonitorConfigManager *config_manager)
   logical_monitor_configs = g_list_append (NULL,
                                            primary_logical_monitor_config);
 
-  return meta_monitors_config_new (monitor_manager,
-                                   logical_monitor_configs,
-                                   layout_mode,
-                                   META_MONITORS_CONFIG_FLAG_NONE);
+  monitors_config = meta_monitors_config_new (monitor_manager,
+                                              logical_monitor_configs,
+                                              layout_mode,
+                                              META_MONITORS_CONFIG_FLAG_NONE);
+
+  if (monitors_config)
+    meta_monitors_config_set_switch_config (monitors_config, META_MONITOR_SWITCH_CONFIG_BUILTIN);
+
+  return monitors_config;
 }
 
 MetaMonitorsConfig *
@@ -1275,9 +1299,6 @@ meta_monitor_config_manager_create_for_switch_config (MetaMonitorConfigManager  
       g_warn_if_reached ();
       return NULL;
     }
-
-  if (config)
-    meta_monitors_config_set_switch_config (config, config_type);
 
   return config;
 }


### PR DESCRIPTION
It is linear config manager created when ensuring configuration.
However, the switch config is not set as LINEAR, but left as UNKNOWN.
This leads switch mode OSD always shows "Join Displays" icon, rather
than the next icon which is "External Only" after connect an external
display and press Super+P once at first time since mutter starts.

This patch moves switch config setting into
meta_monitor_config_manager_create_linear() (and the sibling functions)
to well prepare the monitors config and avoid missing settings.

This is a regression introduced by 149e4d69345a.

https://phabricator.endlessm.com/T30520

Fixes: https://gitlab.gnome.org/GNOME/mutter/-/issues/1362