### PR TITLE
T30174 underscan robustness

### DIFF
--- a/src/backends/meta-monitor-manager.c
+++ b/src/backends/meta-monitor-manager.c
@@ -1345,6 +1345,7 @@ meta_monitor_manager_handle_get_current_state (MetaDBusDisplayConfig *skeleton,
           MetaMonitorMode *monitor_mode = k->data;
           GVariantBuilder supported_scales_builder;
           const char *mode_id;
+          const char *mode_name;
           int mode_width, mode_height;
           float refresh_rate;
           float preferred_scale;
@@ -1357,6 +1358,7 @@ meta_monitor_manager_handle_get_current_state (MetaDBusDisplayConfig *skeleton,
             continue;
 
           mode_id = meta_monitor_mode_get_id (monitor_mode);
+          mode_name = meta_monitor_mode_get_name (monitor_mode);
           meta_monitor_mode_get_resolution (monitor_mode,
                                             &mode_width, &mode_height);
 
@@ -1396,6 +1398,10 @@ meta_monitor_manager_handle_get_current_state (MetaDBusDisplayConfig *skeleton,
             g_variant_builder_add (&mode_properties_builder, "{sv}",
                                    "is-interlaced",
                                    g_variant_new_boolean (TRUE));
+
+          g_variant_builder_add (&mode_properties_builder, "{sv}",
+                                 "mode-name",
+                                 g_variant_new_string (mode_name));
 
           g_variant_builder_add (&modes_builder, MODE_FORMAT,
                                  mode_id,

--- a/src/backends/meta-monitor.c
+++ b/src/backends/meta-monitor.c
@@ -42,6 +42,7 @@ typedef struct _MetaMonitorMode
 {
   MetaMonitor *monitor;
   char *id;
+  char *name;
   MetaMonitorModeSpec spec;
   MetaMonitorCrtcMode *crtc_modes;
 } MetaMonitorMode;
@@ -622,6 +623,7 @@ meta_monitor_normal_generate_modes (MetaMonitorNormal *monitor_normal)
                                              crtc_mode_info->height,
                                              crtc_mode);
       mode->id = generate_mode_id (&mode->spec);
+      mode->name = g_strdup (meta_crtc_mode_get_name (crtc_mode));
       mode->crtc_modes = g_new (MetaMonitorCrtcMode, 1);
       mode->crtc_modes[0] = (MetaMonitorCrtcMode) {
         .output = output,
@@ -1009,7 +1011,7 @@ create_tiled_monitor_mode (MetaMonitorTiled *monitor_tiled,
   mode->parent.spec =
     meta_monitor_create_spec (monitor, width, height, reference_crtc_mode);
   mode->parent.id = generate_mode_id (&mode->parent.spec);
-
+  mode->parent.name = g_strdup (mode->parent.name);
   mode->parent.crtc_modes = g_new0 (MetaMonitorCrtcMode,
                                     g_list_length (monitor_priv->outputs));
   for (l = monitor_priv->outputs, i = 0; l; l = l->next, i++)
@@ -1129,6 +1131,7 @@ create_untiled_monitor_mode (MetaMonitorTiled *monitor_tiled,
                                                 crtc_mode_info->height,
                                                 crtc_mode);
   mode->parent.id = generate_mode_id (&mode->parent.spec);
+  mode->parent.name = g_strdup (mode->parent.name);
   mode->parent.crtc_modes = g_new0 (MetaMonitorCrtcMode,
                                     g_list_length (monitor_priv->outputs));
 
@@ -1496,6 +1499,7 @@ static void
 meta_monitor_mode_free (MetaMonitorMode *monitor_mode)
 {
   g_free (monitor_mode->id);
+  g_free (monitor_mode->name);
   g_free (monitor_mode->crtc_modes);
   g_free (monitor_mode);
 }
@@ -1872,6 +1876,12 @@ const char *
 meta_monitor_mode_get_id (MetaMonitorMode *monitor_mode)
 {
   return monitor_mode->id;
+}
+
+const char *
+meta_monitor_mode_get_name (MetaMonitorMode *monitor_mode)
+{
+  return monitor_mode->name;
 }
 
 void

--- a/src/backends/meta-monitor.h
+++ b/src/backends/meta-monitor.h
@@ -237,6 +237,9 @@ META_EXPORT_TEST
 const char * meta_monitor_mode_get_id (MetaMonitorMode *monitor_mode);
 
 META_EXPORT_TEST
+const char * meta_monitor_mode_get_name (MetaMonitorMode *monitor_mode);
+
+META_EXPORT_TEST
 MetaMonitorModeSpec * meta_monitor_mode_get_spec (MetaMonitorMode *monitor_mode);
 
 META_EXPORT_TEST

--- a/src/backends/x11/meta-gpu-xrandr.c
+++ b/src/backends/x11/meta-gpu-xrandr.c
@@ -83,6 +83,12 @@ get_xmode_name (XRRModeInfo *xmode)
   int width = xmode->width;
   int height = xmode->height;
 
+  if (xmode->hSkew != 0)
+    {
+      width += 2 * (xmode->hSkew >> 8);
+      height += 2 * (xmode->hSkew & 0xff);
+    }
+
   return g_strdup_printf ("%dx%d", width, height);
 }
 

--- a/src/org.gnome.Mutter.DisplayConfig.xml
+++ b/src/org.gnome.Mutter.DisplayConfig.xml
@@ -315,6 +315,7 @@
 	       - "is-current" (b): the mode is currently active mode
 	       - "is-preferred" (b): the mode is the preferred mode
 	       - "is-interlaced" (b): the mode is an interlaced mode
+	       - "mode-name" (s): the name, suitable for showing to the user
 	* a{sv} properties: optional properties, including:
 	    - "width-mm" (i): physical width of monitor in millimeters
 	    - "height-mm" (i): physical height of monitor in millimeters


### PR DESCRIPTION
As discussed on the ticket, this will make g-c-c robust to mutter not having this patch (11a913ad23092bab55aba7df3ce696bec143e616). There will be a g-c-c side of this as well.

https://phabricator.endlessm.com/T30174